### PR TITLE
Fix Beacons & Time-to-wait-after-flagged, Introduce Messaging util w/Debug messages

### DIFF
--- a/src/main/java/io/github/townyadvanced/flagwar/config/FlagWarConfig.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/config/FlagWarConfig.java
@@ -19,6 +19,7 @@ package io.github.townyadvanced.flagwar.config;
 import io.github.townyadvanced.flagwar.FlagWar;
 import com.palmergames.util.TimeTools;
 
+import io.github.townyadvanced.flagwar.util.Messaging;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.plugin.Plugin;
@@ -92,6 +93,16 @@ public final class FlagWarConfig {
     }
 
     /**
+     * Check if extra "debug" messages should be written to the JUL logger on the WARN level.
+     * <p>
+     * (Lazy way to bypass Spigot's log4j settings.)
+     * @return true if configured to show debug messages.
+     */
+    public static boolean isDebugging() {
+        return PLUGIN.getConfig().getBoolean("extra.debug");
+    }
+
+    /**
      * Gets the time between iterations though the {@link #TIMER_MATERIALS}; a fraction of {@link #getFlagWaitingTime()}
      * over the length of the array.
      * @return the temporal difference between color changes, in ticks.
@@ -105,7 +116,9 @@ public final class FlagWarConfig {
      * @return the result of beacon.draw, from the configuration file.
      */
     public static boolean isDrawingBeacon() {
-        return PLUGIN.getConfig().getBoolean("beacon.draw");
+        var beaconIsDrawn = PLUGIN.getConfig().getBoolean("beacon.draw");
+        Messaging.debug("(Config) Should beacons be drawn: %s", new Object[] {beaconIsDrawn});
+        return beaconIsDrawn;
     }
 
     /**

--- a/src/main/java/io/github/townyadvanced/flagwar/config/FlagWarConfig.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/config/FlagWarConfig.java
@@ -154,14 +154,14 @@ public final class FlagWarConfig {
         return getBeaconRadius() * 2 - 1;
     }
 
-    /** @return the beacon's minimum y-value above the flag, as defined by the 'beacon.height_above_flag_min' key. */
+    /** @return the beacon's minimum y-value above the flag, as defined by the 'beacon.height_above_flag.min' key. */
     public static int getBeaconMinHeightAboveFlag() {
-        return PLUGIN.getConfig().getInt("beacon.height_above_flag_min");
+        return PLUGIN.getConfig().getInt("beacon.height_above_flag.min");
     }
 
-    /** @return the value of 'rules.get_time_to_wait_after_flag' as a long (ticks). */
+    /** @return the value of 'rules.time_to_wait_after_flag' as a long (ticks). */
     public static long getTimeToWaitAfterFlagged() {
-        return PLUGIN.getConfig().getLong("rules.get_time_to_wait_after_flagged");
+        return PLUGIN.getConfig().getLong("rules.time_to_wait_after_flagged");
     }
 
     /** @return the value of 'rules.prevent_interaction_while_flagged.town'. */
@@ -174,9 +174,9 @@ public final class FlagWarConfig {
         return PLUGIN.getConfig().getBoolean("rules.prevent_interaction_while_flagged.nation");
     }
 
-    /** @return the value of 'beacon.height_above_flag_max'. */
+    /** @return the value of 'beacon.height_above_flag.max'. */
     public static int getBeaconMaxHeightAboveFlag() {
-        return PLUGIN.getConfig().getInt("beacon.height_above_flag_max");
+        return PLUGIN.getConfig().getInt("beacon.height_above_flag.max");
     }
 
     /**

--- a/src/main/java/io/github/townyadvanced/flagwar/objects/CellUnderAttack.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/objects/CellUnderAttack.java
@@ -27,6 +27,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import io.github.townyadvanced.flagwar.i18n.Translate;
+import io.github.townyadvanced.flagwar.util.Messaging;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -101,6 +102,7 @@ public class CellUnderAttack extends Cell {
     /** Function to load the war beacon. */
     public void loadBeacon() {
         if (!FlagWarConfig.isDrawingBeacon()) {
+            Messaging.debug("loadBeacon() returned. Config:beacon.draw read as false");
             return;
         }
 
@@ -109,21 +111,26 @@ public class CellUnderAttack extends Cell {
 
         int beaconSize = FlagWarConfig.getBeaconSize();
         if (Coord.getCellSize() < beaconSize) {
+            Messaging.debug("loadBeacon() returned. \"Coord#getCellSize()\" smaller than Config:beacon.size");
             return;
         }
 
         var minBlock = getBeaconMinBlock(getFlagBaseBlock().getWorld());
-        if (getMinimumHeightForBeacon() >= minBlock.getY()) {
+        var minHeight = (getTopOfFlagBlock().getY() + FlagWarConfig.getBeaconMinHeightAboveFlag());
+        if (minHeight <= getTopOfFlagBlock().getY()) {
+            Messaging.debug("loadBeacon() returned. Minimum Y-height <= top of flag.");
             return;
         }
 
         int outerEdge = beaconSize - 1;
+        Messaging.debug("(Beacon) Drawing. Now iterating over blocks.");
         for (var y = 0; y < beaconSize; y++) {
             for (var z = 0; z < beaconSize; z++) {
                 for (var x = 0; x < beaconSize; x++) {
                     var block = flagBaseBlock.getWorld().getBlockAt(minBlock.getX() + x,
                         minBlock.getY() + y, minBlock.getZ() + z);
                     if (block.isEmpty()) {
+                        Messaging.debug("(Beacon) Spawning %s at %d, %d, %d", new Object[] {block.toString(), x, y, z});
                         drawBeaconOrWireframe(outerEdge, y, z, x, block);
                     }
                 }
@@ -142,10 +149,6 @@ public class CellUnderAttack extends Cell {
 
     private Block getTopOfFlagBlock() {
         return flagLightBlock;
-    }
-
-    private int getMinimumHeightForBeacon() {
-        return getTopOfFlagBlock().getY() + FlagWarConfig.getBeaconMinHeightAboveFlag();
     }
 
     private int getEdgeCount(final int x, final int y, final int z, final int outerEdge) {

--- a/src/main/java/io/github/townyadvanced/flagwar/objects/CellUnderAttack.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/objects/CellUnderAttack.java
@@ -119,6 +119,8 @@ public class CellUnderAttack extends Cell {
         var minHeight = (getTopOfFlagBlock().getY() + FlagWarConfig.getBeaconMinHeightAboveFlag());
         if (minHeight <= getTopOfFlagBlock().getY()) {
             Messaging.debug("loadBeacon() returned. Minimum Y-height <= top of flag.");
+            Messaging.debug("Top-of-flag: %d, Beacon Min-Height: %d",
+                new Object[]{getTopOfFlagBlock().getY(), minHeight});
             return;
         }
 

--- a/src/main/java/io/github/townyadvanced/flagwar/util/Messaging.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/util/Messaging.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021 TownyAdvanced
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.github.townyadvanced.flagwar.util;
+
+import io.github.townyadvanced.flagwar.FlagWar;
+import io.github.townyadvanced.flagwar.config.FlagWarConfig;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class Messaging {
+    /** Sets the logger to the Bukkit-provided logger. */
+    private static final Logger LOGGER = FlagWar.getInstance().getLogger();
+
+    private Messaging() {
+        throw new IllegalStateException("Utility Class");
+    }
+
+    /**
+     * Sends a simple {@link String} to a given {@link Player}.
+     * @param recipient Player receiving message.
+     * @param str A simple String.
+     */
+    public static void send(@NotNull final Player recipient, @NotNull final String str) {
+        recipient.sendMessage(str);
+    }
+
+    /**
+     * Send a debugMessage (FW_DEBUG: [{@link String}]) over the {@link Logger} via {@link Level#WARNING}.
+     * <p>
+     * Must have the extra.debug config node set to true for the message to be sent.
+     * @param debugMessage Simple String to pass to the logger.
+     */
+    public static void debug(@NotNull final String debugMessage) {
+        if (FlagWarConfig.isDebugging()) {
+            LOGGER.log(Level.WARNING, () -> String.format("FW_DEBUG: %s", debugMessage));
+        }
+    }
+
+    /**
+     * Send a debugMessage (FW_DEBUG: [{@link String}]) over the WARN channel, passing the supplied baseMessage and
+     * arguments to {@link String#format(String, Object...)}.
+     *
+     * @param baseMessage A String, compatible with {@link java.util.Formatter#format(String, Object...)}.
+     * @param args Arguments to pass to the String for formatting.
+     */
+    public static void debug(@NotNull final String baseMessage, @NotNull final Object[] args) {
+        debug((String.format(baseMessage, args)));
+    }
+}

--- a/src/main/java/io/github/townyadvanced/flagwar/util/package-info.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/util/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2021 TownyAdvanced
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/** Contains general utility classes. */
+package io.github.townyadvanced.flagwar.util;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -72,3 +72,7 @@ economy:
     home_block_captured: 100.0
     war_flag_cost: 10.0
     attack_defended_reward: 10.0
+
+extra:
+    # If enabled, show additional debug messages as warnings. Recommended to keep these disabled unless requested.
+    debug: false


### PR DESCRIPTION
#### Brief Description:
<!-- Describe your Pull Request's purpose here please. --->
Closes #34 - Issue result of mismatched configuration keys in the FlagWarConfig class, as well as a comparative error. Both were tracked down by introducing a debugging method, through a messaging utility class.

The keys would default to 0, thus throwing the calculation math off and making beacon minHeight equal to the top of the flag; instead of topOfTheFlag + configuration minHeight. And the comparison was set for if minBlock greater than the top of the flag base block, to return and not draw the beacon.

Also possibly fixes a previously uncaught Time-to-wait-after-flagged setting issue - another case of using the wrong key.

____
#### Changes:
<!-- 
Please state your changes in human-readable format if the Description isn't enough detail. Small PRs
can usually ignore this section, or remove it. However, fairly sized PRs (such as a class rewrite)
should go into detail about the changes here.
-->

- New: Messaging Class (`io.github.townyadvanced.flagwar.util.Messaging`)
  - Two Debug message methods: debug(String) and debug(String, Object[])
    - Appends `FW_DEBUG: {string}` to log/term on the WARN level
  - One send(Player, String) object.
    - Passes `Player.sendMessage(String)`

- New Config Node:
  - extra.debug: Defaults to False. When true, debug messages will be sent to the logger. Potentially spammy, but that's exactly what debugging is supposed to do.

- Invert a boolean beacon return check:
  - Was: if minHeight >= baseOfFlag, return.
    - Never draws, because minHeight is always topOfFlag + beacon.heightAboveFlag.min, leaving the expression always true.
  - Is: if minHeight <= topOfFlag, return.
    - Pretty confident that this closes Issue #34, but will have to push in order to pull to my test server.

- New Debug Messages:
  - Sent when isDrawingBeacon is called
  - Sent when a beacon block is supposed to be placed
  - Sent if a beacon cannot be loaded due to an early return
    - Example A: Coord#getCellSize() < Config:beacon.size
    - Example B: Config:beacon.height_above_flag.min <= getBeaconMinBlock().getY()#### Brief 

____
#### Relevant FlagWar Issue tickets:
<!--
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
If you add issues manually on the sidebar, you can safely delete this heading. If using keywords,
please use an unordered list should you need to reference more than one issue.
--->
- #34 


____
- [x] I have tested this pull request for defects on a server.
<!-- Replace `[ ]` with `[x]` if completed. --->

---
By making this pull request, I represent that I have read and agree to release my own changes that I
have submitted under the terms of the accompanying license (Apache-2.0). I guarantee that these
changes are mine and are not encumbered by any other license or restriction to the best of my
knowledge.

<!-- For co-authored commits, all co-authors will need to reply to this PR within a 48 Hrs.
If no replies have been left within a reasonable period, we may attempt to contact them by their
email tied to their commits, OR reject the PR at our discretion.

For Co-authoring docs, see:
https://docs.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors
--->