### PR TITLE
Fix Bukkit "&" Color Code Parsing

### DIFF
--- a/src/main/java/io/github/townyadvanced/flagwar/i18n/Translate.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/i18n/Translate.java
@@ -16,6 +16,8 @@
 
 package io.github.townyadvanced.flagwar.i18n;
 
+import com.palmergames.bukkit.util.Colors;
+
 /**
  * Helper class for abstracting away locale utilities.
  */
@@ -33,7 +35,7 @@ public final class Translate {
      * @return A translated String, with parsed arguments.
      */
     public static String from(final String translationKey, final Object... args) {
-        return String.format(LocaleUtil.getMessages().getString(translationKey), args);
+        return Colors.translateColorCodes(String.format(LocaleUtil.getMessages().getString(translationKey), args));
     }
 
     /**
@@ -44,7 +46,7 @@ public final class Translate {
      */
     public static String from(final String translationKey) {
         // Redundant call to format() is intentional
-        return String.format(LocaleUtil.getMessages().getString(translationKey));
+        return Colors.translateColorCodes(String.format(LocaleUtil.getMessages().getString(translationKey)));
     }
 
     /**


### PR DESCRIPTION
#### Brief Description:
<!-- Describe your Pull Request's purpose here please. --->
Fix "&'" color code parsing in FlagWar messaging. In the future it will enable 1.16+ hex color codes as well.
____
#### Changes:
<!-- 
Please state your changes in human-readable format if the Description isn't enough detail. Small PRs
can usually ignore this section, or remove it. However, fairly sized PRs (such as a class rewrite)
should go into detail about the changes here.
-->
Made strings from i18n.Translate#from() go through Towny's Colors#translateColorCodes() method.
____
#### Relevant FlagWar Issue tickets:
<!--
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
If you add issues manually on the sidebar, you can safely delete this heading. If using keywords,
please use an unordered list should you need to reference more than one issue.
--->
#33 

____
- [x] I have tested this pull request for defects on a server.
<!-- Replace `[ ]` with `[x]` if completed. --->

---
By making this pull request, I represent that I have read and agree to release my own changes that I
have submitted under the terms of the accompanying license (Apache-2.0). I guarantee that these
changes are mine and are not encumbered by any other license or restriction to the best of my
knowledge.

<!-- For co-authored commits, all co-authors will need to reply to this PR within a 48 Hrs.
If no replies have been left within a reasonable period, we may attempt to contact them by their
email tied to their commits, OR reject the PR at our discretion.

For Co-authoring docs, see:
https://docs.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors
--->
