### PR TITLE
Add Feature: Alternative Flag Timer Materials

### DIFF
--- a/src/main/java/io/github/townyadvanced/flagwar/config/FlagWarConfig.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/config/FlagWarConfig.java
@@ -32,7 +32,7 @@ public final class FlagWarConfig {
         super();
     }
 
-    /** Default timer materials */
+    /** Default timer materials. */
     private static final Material[] DEFAULT_TIMER_MATERIALS = new Material[] {
         Material.LIME_WOOL, Material.GREEN_WOOL, Material.BLUE_WOOL, Material.CYAN_WOOL,
         Material.LIGHT_BLUE_WOOL, Material.GRAY_WOOL, Material.WHITE_WOOL,
@@ -52,8 +52,8 @@ public final class FlagWarConfig {
     /**
      * {@link Material} array used for representing the FlagWar Flag Timer, used in both beacons and tops of War Flags.
      */
-    static final Material[] TIMER_MATERIALS = isUsingDefaultTimerBlocks() ?
-        DEFAULT_TIMER_MATERIALS : getCustomTimerBlocks();
+    static final Material[] TIMER_MATERIALS = isUsingDefaultTimerBlocks()
+        ? DEFAULT_TIMER_MATERIALS : getCustomTimerBlocks();
 
     /**
      * Checks if a {@link Material} should be affected by an operation.

--- a/src/main/java/io/github/townyadvanced/flagwar/i18n/Translate.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/i18n/Translate.java
@@ -16,6 +16,8 @@
 
 package io.github.townyadvanced.flagwar.i18n;
 
+import com.palmergames.bukkit.util.Colors;
+
 /**
  * Helper class for abstracting away locale utilities.
  */
@@ -33,7 +35,7 @@ public final class Translate {
      * @return A translated String, with parsed arguments.
      */
     public static String from(final String translationKey, final Object... args) {
-        return String.format(LocaleUtil.getMessages().getString(translationKey), args);
+        return Colors.translateColorCodes(String.format(LocaleUtil.getMessages().getString(translationKey), args));
     }
 
     /**
@@ -44,7 +46,7 @@ public final class Translate {
      */
     public static String from(final String translationKey) {
         // Redundant call to format() is intentional
-        return String.format(LocaleUtil.getMessages().getString(translationKey));
+        return Colors.translateColorCodes(String.format(LocaleUtil.getMessages().getString(translationKey)));
     }
 
     /**

--- a/src/main/java/io/github/townyadvanced/flagwar/i18n/Translate.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/i18n/Translate.java
@@ -16,8 +16,6 @@
 
 package io.github.townyadvanced.flagwar.i18n;
 
-import com.palmergames.bukkit.util.Colors;
-
 /**
  * Helper class for abstracting away locale utilities.
  */
@@ -35,7 +33,7 @@ public final class Translate {
      * @return A translated String, with parsed arguments.
      */
     public static String from(final String translationKey, final Object... args) {
-        return Colors.translateColorCodes(String.format(LocaleUtil.getMessages().getString(translationKey), args));
+        return String.format(LocaleUtil.getMessages().getString(translationKey), args);
     }
 
     /**
@@ -46,7 +44,7 @@ public final class Translate {
      */
     public static String from(final String translationKey) {
         // Redundant call to format() is intentional
-        return Colors.translateColorCodes(String.format(LocaleUtil.getMessages().getString(translationKey)));
+        return String.format(LocaleUtil.getMessages().getString(translationKey));
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -58,6 +58,24 @@ flag:
     base_block: 'OAK_FENCE' # Block required to place a flag.
     light_block: 'TORCH' # TORCH and SOUL_TORCH good. REDSTONE_TORCH questionable.
 
+# Defines the War Flag timer blocks.
+timer_blocks:
+    # Will use the classic wool palette if true.
+    use_default: true
+    # Will set the timer blocks. Each entry is allotted an equal amount of time.
+    # Use multiple entries to achieve more granularity. Case-insensitive.
+    blocks:
+        - lime_terracotta
+        - green_terracotta
+        - blue_terracotta
+        - cyan_terracotta
+        - light_blue_terracotta
+        - gray_terracotta
+        - white_terracotta
+        - pink_terracotta
+        - orange_terracotta
+        - red_terracotta
+
 # Define Beacon Structure
 beacon:
     draw: true


### PR DESCRIPTION
#### Brief Description:
<!-- Describe your Pull Request's purpose here please. --->
Add alternative flag timer materials. Granular intervals can be achieved as originally suggested by adding multiple entries to the config. For example, 3 entries of ancient debris, 5 of obsidian, and a flag length of 8 minutes would satisfy the example in the original suggestion.
____
#### Changes:
<!-- 
Please state your changes in human-readable format if the Description isn't enough detail. Small PRs
can usually ignore this section, or remove it. However, fairly sized PRs (such as a class rewrite)
should go into detail about the changes here.
-->
## Changes in FlagWarConfig.java:
* Add logger to FlagWarConfig
  * Used in #getCustomTimerBlocks()
* Move old classic wool TIMER_MATERIALS to DEFAULT_TIMER_MATERIALS
* Add boolean #isUsingDefaultTimerBlocks
  * Used in new TIMER_MATERIALS
  * Checks config boolean value "timer_blocks.use_default"
* Add new TIMER_MATERIALS
  * Checks value of #isUsingDefaultTimerBlocks()
    * If true, is set to DEFAULT_TIMER_MATERIALS
    * If false, is set to #getCustomTimerBlocks()
* Add #getCustomTimerBlocks()
  * Gets list of materials from config.yml, timer_blocks.blocks
    * If the list is missing, will return null as default value.
    * An error will be logged and DEFAULT_TIMER_MATERIALS is returned.
  * If list is not null, attempts to convert each entry to a Material
    * If all entries are valid, the custom material list is returned
    * If one or more entries are invalid, an error is logged and the default list is returned.

## Changes in config.yml
* Add section: timer_blocks
  * Add timer_blocks.use_default
    * If true, will use classic wool timer blocks.
    * If false, blocks list will be used.
  * Add timer_blocks.blocks
    * List of materials to be used if use_default is false.
    * Must be a valid Bukkit Material.
    * Case-insensitive.
    * A sample palette of terracotta is included.
____
#### Relevant FlagWar Issue tickets:
<!--
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
If you add issues manually on the sidebar, you can safely delete this heading. If using keywords,
please use an unordered list should you need to reference more than one issue.
--->
Closes #5 

____
- [x] I have tested this pull request for defects on a server.
<!-- Replace `[ ]` with `[x]` if completed. --->

---
By making this pull request, I represent that I have read and agree to release my own changes that I
have submitted under the terms of the accompanying license (Apache-2.0). I guarantee that these
changes are mine and are not encumbered by any other license or restriction to the best of my
knowledge.

<!-- For co-authored commits, all co-authors will need to reply to this PR within a 48 Hrs.
If no replies have been left within a reasonable period, we may attempt to contact them by their
email tied to their commits, OR reject the PR at our discretion.

For Co-authoring docs, see:
https://docs.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors
--->
