### PR TITLE
Update development target to Minecraft 1.17; Restore WarzoneListener

### DIFF
--- a/.github/workflows/compile-on-push.yml
+++ b/.github/workflows/compile-on-push.yml
@@ -14,4 +14,4 @@ jobs:
             - name: Compile with Maven
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: mvn -B compile test -P checkstyle,javadocs -X
+              run: mvn -B compile test -P checkstyle,javadocs

--- a/.github/workflows/compile-on-push.yml
+++ b/.github/workflows/compile-on-push.yml
@@ -14,4 +14,4 @@ jobs:
             - name: Compile with Maven
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: mvn -B compile test -P alternatives,checkstyle,javadocs
+              run: mvn -B compile test -P alternatives,checkstyle,javadocs -X

--- a/.github/workflows/compile-on-push.yml
+++ b/.github/workflows/compile-on-push.yml
@@ -5,11 +5,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - name: Set up OpenJDK 11
+            - name: Set up OpenJDK 16
               uses: actions/setup-java@v2
               with:
                   distribution: 'adopt'
-                  java-version: '11'
+                  java-version: '16'
+                  java-package: jdk
             - name: Compile with Maven
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compile-on-push.yml
+++ b/.github/workflows/compile-on-push.yml
@@ -14,4 +14,4 @@ jobs:
             - name: Compile with Maven
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: mvn -B compile test -P alternatives,checkstyle,javadocs -X
+              run: mvn -B compile test -P checkstyle,javadocs -X

--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -9,11 +9,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - name: Set up OpenJDK 11
+            - name: Set up OpenJDK 16
               uses: actions/setup-java@v2
               with:
-                  distribuition: 'adopt'
-                  java-version: '11'
+                  distribution: 'adopt'
+                  java-version: '16'
+                  java-package: jdk
             - name: Deploy to GitHub Package Registry
               run: mvn -B deploy -P alternatives,checkstyle,javadocs
               env:

--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -16,6 +16,6 @@ jobs:
                   java-version: '16'
                   java-package: jdk
             - name: Deploy to GitHub Package Registry
-              run: mvn -B deploy -P alternatives,checkstyle,javadocs
+              run: mvn -B deploy -P alternatives,checkstyle,javadocs -X
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -16,6 +16,6 @@ jobs:
                   java-version: '16'
                   java-package: jdk
             - name: Deploy to GitHub Package Registry
-              run: mvn -B deploy -P checkstyle,javadocs -X
+              run: mvn -B deploy -P checkstyle,javadocs
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -16,6 +16,6 @@ jobs:
                   java-version: '16'
                   java-package: jdk
             - name: Deploy to GitHub Package Registry
-              run: mvn -B deploy -P alternatives,checkstyle,javadocs -X
+              run: mvn -B deploy -P checkstyle,javadocs -X
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -10,7 +10,7 @@
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>
-      <module name="FlagWar" target="11" />
+      <module name="FlagWar" target="16" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 ### Important Notices
 
 <details><summary>Development Software</summary>
-FlagWar is not yet ready to be considered "Stable". Please consider all currently available builds to be 
-development builds.
+
+FlagWar is not yet considered "Stable". Releases will have bugs, or be out of date with the code.
+Releases provided as a courtesy to users wanting to try it out for themselves.
 
 Some features will likely still be missing or broken.
 For known deficiencies, please refer to the [issue tracker][issue-tracker] and/or
@@ -20,7 +21,7 @@ If you would like to help out with development, translations, or other efforts: 
 
 FlagWar, makes use of the [bStats](https://bstats.org/) metrics library. For an idea of what is collected, you can view
 the telemetry reports [here](https://bstats.org/plugin/bukkit/FlagWar/10325).
-While we would appreciate it if you were to keep reporting enabled, you can opt-out of sending telemetry
+While we would appreciate it if you were to keep bstats reporting enabled, you can opt-out of sending telemetry
 by modifying the bStats config found at `yourServer/plugins/bStats/`.
 </details>
 
@@ -96,9 +97,12 @@ Administrator Resources
 
 <img align=right src="https://user-images.githubusercontent.com/879756/65964779-3a067200-e423-11e9-9928-938b976af2c2.gif" height="155">
 
-All Release builds and Development builds are being made available here on GitHub's [Releases][releases] page.
+All Release builds and Development builds have been made available here on GitHub's [Releases][releases] page.
 We encourage server admins to "watch" FlagWar on GitHub in order to receive update notifications.
 Just click the watch button in the upper right and select "Releases Only".
+
+Sometimes, releases can be incubating for extended periods of time. You can build from main if you want to test on 
+the bleeding edge.
 
 ### Getting Support
 
@@ -121,30 +125,29 @@ Developer Resources
 
 If you would like to contribute to the FlagWar code, first please read the [Contributing Guidelines][contributing].
 
-For basic work, involving only minor changes (1-2 lines), you _can_ use GitHub's built-in editor after
-forking the project.
-
-For anything more involved, you will need to fulfill the following requirements:
-- A [Java Development Kit][jdk], for Java 11 or higher
-- A competent text editor (documentation, translations), or an Integrated Development Environment (code)
-    - Competent Editors: 
-      [Atom][atom], [Notepad++][npp], [Sublime Text][sublime], [Vim][vim], [Visual Studio Code][vscode]
-    - Recommendable IDEs: [Apache NetBeans][netbeans], [Eclipse IDE][eclipse], [IntelliJ IDEA][idea]
-- Apache Maven (_See [Building FlagWar](#building-flagwar); Note that some IDEs bundle a JDK and Apache Maven, or
-  can grab them for you._)
+You will also want to ensure that your working environment is in order. You can check out
+[Environment Setup][env-setup] over on our wiki to help you get started.
 
 ### Contributing Documentation
-Help with the documentation would be much appreciated.
-If you are interested in writing for the wiki, please create a ticket, adk on the Towny Discord,
-or chime in on the Towny discussion board to be given write access. 
+
+Documentation could also use a fair bit of work. Help in this department would be much appreciated.
+
+We document both in plain-text (LICENSE, NOTICE) and in GitHub-Flavored Markdown (everywhere else).
+
+If you are interested in writing for the [FlagWar Wiki][wiki], feel free to ask on the [Towny Discord][discord]
+(ping FlagCourier), or chime in on the [Towny Discussion Board][discuss-towny] to be given write access. 
 
 ### Localizing FlagWar
 
-The localization files for FlagWar are built directly into the jarfile using ResourceBundles.
+The localization files for FlagWar are built directly into the jar using ResourceBundles.
 
 To localize FlagWar to your language, copy the 
 [Translation_en_US.properties](src/main/resources/Translation_en_US.properties) file from the
 [`resources` directory](src/main/resources) as `Translation_{LOCALE}.properties`.
+
+If a locale already exists, please refrain from creating a duplicate. Some locales may be stubs that were added for
+debugging purposes (en_GB, en_US[-_]POSIX, es_MX.) Feel free to modify them, but ensure they have the same key values
+as the master file (en_US).
 
 The `LOCALE`, or the locale id compatible with the Java Locale class,
 is a 1-to-3 segment string representing the _language_, the _region_, and the _variant_ (if desired);
@@ -155,28 +158,29 @@ Examples: en, en_US, en_US-POSIX.
 See the Java [Locale](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Locale.html) documentation 
 for well-formed naming. 
 
-> &ast; FlagWar does not support `script` or `extension` fields, so Locale IDs should stick to the 
-`lang(_REGION([_\-]VARIANT))` format.  
+> &ast; FlagWar's Locale IDs should stick to the `lang(_REGION([_\-]VARIANT))` format.  
 > PRs to Locale processing are welcome. It's pretty messy in there...
-Once you have that done, you can go ahead and translate the strings from there.
 
 After translation is complete, save your changes. You will need to [Build FlagWar](README.md#Building-FlagWar) to ensure
 that all strings are accounted for, and that they render properly for end users.
 
 ### Building FlagWar
 
-Building FlagWar requires the use of [Apache Maven][maven], [Git][git] (optional), a [Java Development Kit][jdk] for
-Java 11 (or greater; [Amazon Corretto recommended][corretto]), and an internet connection.
+Assuming you've got your [environment properly set up][env-setup], building FlagWar is relatively straight forward.
 
-1) Clone FlagWar from GitHub. _See the [GitHub Docs][github-docs], if you are unfamiliar with cloning projects._
-2) In a terminal shell, navigate into the cloned `FlagWar` directory. Or, if your OS supports opening a terminal from a
-   directory in its file browser, you can do that.
-3) Run `mvn clean package` to build FlagWar. This will put generated files into the `FlagWar/target` directory.
-   
-   > 💡 If you are on Linux and get JAVA_HOME errors, try adding the `-P alternatives` flag to your
-   > Maven command(s).
+Steps:
+1) Clone FlagWar from GitHub.
+    - _See the [GitHub Docs][github-docs], if you are unfamiliar with cloning projects._
+2) Navigate into the cloned `FlagWar` directory in your terminal.
+3) Run `mvn clean package` to build FlagWar. This will generate files to the `FlagWar/target/` directory.
+    - We also supply several maven profiles for convenience. Append `-P profileX,profileY,profileZ` to use them,
+      obviously replacing the ridiculous placeholder profiles listed here.
+    - 💡 If you are on Linux and get JAVA_HOME errors, try using the  `alternatives` profile.
+    - The `checkstyle` profile will ensure that code edits are in-line with the code style guidelines.
+    - The `javadocs` profile will generate a `FlagWar-version-javadoc.jar` file, as well as the
+      `FlagWar/target/apidocs/` folder.
 
-Alternatively, you can build it through your IDE, provided that it includes Maven, or that
+You can alternatively build FlagWar through your IDE, provided that it includes Maven, or that
 it can at least find it. Check your IDE's documentation regarding Maven support.
 
 Supporting the Project
@@ -192,13 +196,12 @@ You can support the project in multiple ways:
   
 
 - **Sponsor a Developer 💗**  
-  Sponsoring a developer is appreciated, and gives back to those who have spent time to keep the project going.  
+  Sponsoring a developer gives back to those who have spent time to keep the project going.  
   See the sidebar for open sponsorships and learn about GitHub's [Sponsors Program][gh-sponsors].
-  
 
 - **Use FlagWar ⛳**  
-  Using FlagWar lets us know that people still love the war system. It can be encouraging for everyone involved.  
-  Keeping metrics on, while optional, also gives us a rough idea of the health and adoption of FlagWar in the
+  Using FlagWar lets us know that people still love the war system.  
+  Keeping metrics on, while optional, also gives us a rough idea of the adoption of FlagWar in the
   TownyAdvanced ecosystem.
 
 <!-- Links -->
@@ -219,6 +222,7 @@ You can support the project in multiple ways:
 [discord]: https://discord.gg/gnpVs5m "Join the TownyAdvanced Discord server"
 [discuss-towny]: https://github.com/TownyAdvanced/Towny/discussions/categories/q-a "View Towny's Q&A Discussion Board"
 [eclipse]: https://www.eclipse.org/eclipseide/ "The Leading Open Platform for Professional Developers"
+[env-setup]: https://github.com/TownyAdvanced/FlagWar/wiki/Environment-Setup "FlagWar Docs: Environment Setup"
 [feature]: https://github.com/TownyAdvanced/FlagWar/issues/new?assignees=&labels=&template=feature_request.md&title=Suggestion%3A+ "Request a new feature or tweak"
 [get-support]: README.md#getting-support "Getting Support"
 [gh-sponsors]: https://github.com/sponsors "Invest in the software that powers your world"

--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ Steps:
 3) Run `mvn clean package` to build FlagWar. This will generate files to the `FlagWar/target/` directory.
     - We also supply several maven profiles for convenience. Append `-P profileX,profileY,profileZ` to use them,
       obviously replacing the ridiculous placeholder profiles listed here.
-    - 💡 If you are on Linux and get JAVA_HOME errors, try using the  `alternatives` profile.
     - The `checkstyle` profile will ensure that code edits are in-line with the code style guidelines.
     - The `javadocs` profile will generate a `FlagWar-version-javadoc.jar` file, as well as the
       `FlagWar/target/apidocs/` folder.

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
         <java.version>16</java.version>
         <project.bukkitAPIVersion>1.17</project.bukkitAPIVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <plugin.javadoc.version>3.3.1-SNAPSHOT</plugin.javadoc.version>
     </properties>
 
     <licenses>
@@ -201,7 +200,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${plugin.javadoc.version}</version>
+                        <version>3.3.0</version>
                         <executions>
                             <execution>
                                 <phase>compile</phase>
@@ -247,32 +246,6 @@
                                 <phase>validate</phase>
                                 <goals>
                                     <goal>check</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <!-- Use if you need Javadocs on Linux distributions using the (update-)alternatives system. -->
-            <id>alternatives</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${plugin.javadoc.version}</version>
-                        <configuration>
-                            <source>${java.version}</source>
-                            <javadocExecutable>/usr/bin/javadoc</javadocExecutable>
-                            <notimestamp>true</notimestamp>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>jar</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <groupId>io.github.townyadvanced.flagwar</groupId>
     <artifactId>FlagWar</artifactId>
     <packaging>jar</packaging>
-    <version>0.2.0</version>
+    <version>0.2.1-SNAPSHOT</version>
     <description>An OG war system for TownyAdvanced. Celebrating a decade of Flag-based Towny Warfare.</description>
 
     <properties>
-        <java.version>11</java.version>
-        <project.bukkitAPIVersion>1.16</project.bukkitAPIVersion>
+        <java.version>16</java.version>
+        <project.bukkitAPIVersion>1.17</project.bukkitAPIVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <plugin.javadoc.version>3.3.0</plugin.javadoc.version>
     </properties>
@@ -62,9 +62,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.destroystokyo.paper</groupId>
+            <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <version>1.17-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,13 @@
         </dependency>
     </dependencies>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>apache.snapshots</id>
+            <url>https://repository.apache.org/snapshots/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <build>
         <defaultGoal>clean package</defaultGoal>
         <plugins>
@@ -112,7 +119,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.3.0-SNAPSHOT</version>
                 <configuration>
                     <relocations>
                         <relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <java.version>16</java.version>
         <project.bukkitAPIVersion>1.17</project.bukkitAPIVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <plugin.javadoc.version>3.3.0</plugin.javadoc.version>
+        <plugin.javadoc.version>3.3.1-SNAPSHOT</plugin.javadoc.version>
     </properties>
 
     <licenses>

--- a/src/main/java/io/github/townyadvanced/flagwar/config/FlagWarConfig.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/config/FlagWarConfig.java
@@ -84,9 +84,9 @@ public final class FlagWarConfig {
         List<?> blocks = PLUGIN.getConfig().getList("timer_blocks.blocks", null);
         if (blocks != null) {
             int i = blocks.size();
-            Material[] materials = new Material[i];
+            var materials = new Material[i];
             try {
-                for (int j = 0; j < i; j++) {
+                for (var j = 0; j < i; j++) {
                     materials[j] = Material.valueOf(String.valueOf(blocks.get(j)).toUpperCase());
                 }
                 return materials;

--- a/src/main/java/io/github/townyadvanced/flagwar/listeners/WarzoneListener.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/listeners/WarzoneListener.java
@@ -152,8 +152,8 @@ public class WarzoneListener implements Listener {
      */
     private boolean isFastFailing(final TownBlockStatus townBlockStatus, final TownyActionEvent townyActionEvent) {
         return !townBlockStatus.equals(TownBlockStatus.WARZONE)
-            && !FlagWarConfig.isAllowingAttacks()
-            && townyActionEvent.isInWilderness();
+            || !FlagWarConfig.isAllowingAttacks()
+            || townyActionEvent.isInWilderness();
     }
 
     /**

--- a/src/main/java/io/github/townyadvanced/flagwar/objects/Cell.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/objects/Cell.java
@@ -130,10 +130,9 @@ public class Cell {
         if (obj == this) {
             return true;
         }
-        if (!(obj instanceof Cell)) {
+        if (!(obj instanceof Cell that)) {
             return false;
         }
-        Cell that = (Cell) obj;
         return xVal == that.xVal && zVal == that.zVal && (Objects.equals(this.cellsWorldName, that.cellsWorldName));
     }
 

--- a/src/main/java/io/github/townyadvanced/flagwar/objects/CellUnderAttack.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/objects/CellUnderAttack.java
@@ -305,18 +305,6 @@ public class CellUnderAttack extends Cell {
     }
 
     /**
-     * Legacy method that would return if the given {@link Block} was the {@link #flagTimerBlock}.
-     * @param block the supplied Block.
-     * @return the result of {@link #isFlagTimer(Block)}.
-     * @deprecated since FlagWar 0.1.2, marked for future removal. Use {@link #isFlagTimer(Block)} or
-     * {@link #isFlagPart(Block)} instead.
-     */
-    @Deprecated(since = "0.1.2", forRemoval = true)
-    public boolean isFlag(final Block block) {
-        return isFlagTimer(block);
-    }
-
-    /**
      * Check to see if the supplied {@link Block} is part of the war flag's construction.
      * @param block the supplied Block.
      * @return TRUE if the supplied block matches any of the conditions.


### PR DESCRIPTION
#### Brief Description:
<!-- Describe your Pull Request's purpose here please. --->
This PR is does the following:
- Updates the build environment for Java 16 and Paper 1.17
  - Removes the `alternatives` maven profile, as it conflicts with the build.
- Restore  `WarzoneListener` to functionality, without failing over onBuild / onDestroy events.
- Removes the deprecated `CellUnderAttack#isFlag(Block)` method.

____
- [x] I have tested this pull request for defects on a server.
  - Testing done on Paper 1.17, build 20; Towny 0.97.0.6; using a non-operator, permission-free user.
<!-- Replace `[ ]` with `[x]` if completed. --->

---
By making this pull request, I represent that I have read and agree to release my own changes that I
have submitted under the terms of the accompanying license (Apache-2.0). I guarantee that these
changes are mine and are not encumbered by any other license or restriction to the best of my
knowledge.

<!-- For co-authored commits, all co-authors will need to reply to this PR within a 48 Hrs.
If no replies have been left within a reasonable period, we may attempt to contact them by their
email tied to their commits, OR reject the PR at our discretion.

For Co-authoring docs, see:
https://docs.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors
--->
