### PR TITLE
Add War Flag Holograms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,6 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
-        <repository>
-            <id>codemc-repo</id>
-            <url>https://repo.codemc.io/repository/maven-public/</url>
-        </repository>
     </repositories>
 
     <dependencies>
@@ -96,7 +92,7 @@
         <dependency>
             <groupId>com.gmail.filoghost.holographicdisplays</groupId>
             <artifactId>holographicdisplays-api</artifactId>
-            <version>2.4.8</version>
+            <version>2.4.5</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,10 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
+        <repository>
+            <id>codemc-repo</id>
+            <url>https://repo.codemc.io/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -88,6 +92,12 @@
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
             <version>2.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.gmail.filoghost.holographicdisplays</groupId>
+            <artifactId>holographicdisplays-api</artifactId>
+            <version>2.4.8</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
             <version>2.2.1</version>
         </dependency>
         <dependency>
-            <groupId>com.gmail.filoghost.holographicdisplays</groupId>
+            <groupId>com.github.filoghost.HolographicDisplays</groupId>
             <artifactId>holographicdisplays-api</artifactId>
             <version>2.4.5</version>
             <scope>provided</scope>

--- a/src/main/java/io/github/townyadvanced/flagwar/HologramUpdateThread.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/HologramUpdateThread.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 TownyAdvanced
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.github.townyadvanced.flagwar;
+
+import io.github.townyadvanced.flagwar.objects.CellUnderAttack;
+
+import java.util.TimerTask;
+
+/**
+ * Each {@link CellUnderAttack}'s hologram timer thread, extending the {@link TimerTask}.
+ */
+public class HologramUpdateThread extends TimerTask {
+
+    /** Holds the relevant {@link CellUnderAttack}, assigned by the constructor. */
+    private final CellUnderAttack cell;
+
+    /**
+     * Constructs the {@link HologramUpdateThread} for a given {@link CellUnderAttack}.
+     * @param cellUnderAttack to assign the CellAttackThread to.
+     */
+    public HologramUpdateThread(final CellUnderAttack cellUnderAttack) {
+
+        this.cell = cellUnderAttack;
+    }
+
+    /**
+     * Updates the hologram of the war flag within the {@link CellUnderAttack}
+     */
+    @Override
+    public void run() {
+
+        cell.updateHologram();
+    }
+}

--- a/src/main/java/io/github/townyadvanced/flagwar/HologramUpdateThread.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/HologramUpdateThread.java
@@ -38,7 +38,7 @@ public class HologramUpdateThread extends TimerTask {
     }
 
     /**
-     * Updates the hologram of the war flag within the {@link CellUnderAttack}
+     * Updates the hologram of the war flag within the {@link CellUnderAttack}.
      */
     @Override
     public void run() {

--- a/src/main/java/io/github/townyadvanced/flagwar/config/FlagWarConfig.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/config/FlagWarConfig.java
@@ -61,7 +61,7 @@ public final class FlagWarConfig {
         ? DEFAULT_TIMER_MATERIALS : getCustomTimerBlocks();
 
     /** Holds the result of {@link #isHologramEnabled(boolean)}. */
-    static boolean isHologramEnabled = isHologramEnabled(true);
+    private static boolean isHologramEnabled = isHologramEnabled(true);
 
     /**
      * Holds the hologram settings. First checks {@link #isHologramEnabled()}, and if true retrieves the
@@ -71,10 +71,10 @@ public final class FlagWarConfig {
         ? getHologramConfig() : null;
 
     /** Holds whether or not a valid hologram timer line is supplied in the config. */
-    static boolean hasTimerLine;
+    private static boolean hasTimerLine;
 
     /** Holds the text of the hologram timer line, if it exists. */
-    static String timerText;
+    private static String timerText;
 
     /**
      * Checks if a {@link Material} should be affected by an operation.
@@ -133,9 +133,10 @@ public final class FlagWarConfig {
     /**
      * Check if Holograms are enabled in the config, and if HolographicDisplays is present. Also, if Holograms are
      * enabled, but HolographicDisplays is missing, log an error and return false.
+     * @param checkConfig Overload parameter, not used for anything else
      * @return True if both conditions are true.
      */
-    private static boolean isHologramEnabled(boolean checkConfig) {
+    private static boolean isHologramEnabled(final boolean checkConfig) {
         if (PLUGIN.getConfig().getBoolean("holograms.enabled")) {
             if (PLUGIN.getServer().getPluginManager().isPluginEnabled("HolographicDisplays")) {
                 return true;
@@ -161,6 +162,7 @@ public final class FlagWarConfig {
      * color codes, validate the type and data, and add the line to the hologram settings. If type or data are invalid,
      * log the error, and set the line to an empty one. Finally, return the parsed hologram settings as a {@link List}
      * of {@link Map.Entry}'s containing the type and data of each line.
+     * @return Hologram settings {@link List}.
      */
     public static List<Map.Entry<String, String>> getHologramConfig() {
         ConfigurationSection holoLines = PLUGIN.getConfig().getConfigurationSection("holograms.lines");
@@ -182,7 +184,7 @@ public final class FlagWarConfig {
         for (int i = 0; i < maxIdx + 1; i++) {
             String lineType = holoLines.getString(i + ".type", "empty");
             String data = Colors.translateColorCodes(holoLines.getString(i + ".data", "null"));
-            switch(lineType.toLowerCase()) {
+            switch (lineType.toLowerCase()) {
                 case "item":
                     if (Material.matchMaterial(data) == null) {
                         LOGGER.severe(String.format("Invalid hologram material %s for line %s!", data, i));
@@ -233,7 +235,7 @@ public final class FlagWarConfig {
      * @param list The hologram settings list.
      * @param i The hologram line index being parsed, used for error logging.
      */
-    private static void setEmpty(List<Map.Entry<String, String>> list, int i) {
+    private static void setEmpty(final List<Map.Entry<String, String>> list, final int i) {
         if (i != 0) {
             LOGGER.severe("Setting to empty line.");
             list.add(new AbstractMap.SimpleEntry<>("empty", "null"));

--- a/src/main/java/io/github/townyadvanced/flagwar/objects/CellUnderAttack.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/objects/CellUnderAttack.java
@@ -91,7 +91,8 @@ public class CellUnderAttack extends Cell {
         this.flagPhaseID = 0;
         this.thread = -1;
         hologramThread = -1;
-        this.time = (int) (FlagWarConfig.getFlagWaitingTime() / 20L);
+        final long ticksInSecond = 20L;
+        this.time = (int) (FlagWarConfig.getFlagWaitingTime() / ticksInSecond);
 
         var world = flagBase.getWorld();
         this.flagTimerBlock = world.getBlockAt(flagBase.getX(), flagBase.getY() + 1, flagBase.getZ());
@@ -294,12 +295,13 @@ public class CellUnderAttack extends Cell {
                 case "timer":
                     timerLine = hologram.appendTextLine(formatTime(time, data));
                     break;
-                case "empty":
+                default:
                     hologram.appendTextLine("");
-                    break;
             }
         }
-        hologram.teleport(loc.add(0.5, 0.9 + hologram.getHeight(), 0.5));
+        final double hOffset = 0.5d;
+        final double vOffset = 0.9d;
+        hologram.teleport(loc.add(hOffset, vOffset + hologram.getHeight(), hOffset));
         hologram.getVisibilityManager().setVisibleByDefault(true);
     }
 
@@ -321,15 +323,17 @@ public class CellUnderAttack extends Cell {
     /**
      * Function used to format the hologram {@link #time} according to the timer text defined in
      * {@link FlagWarConfig#getTimerText()}.
-     * @param time Time, in seconds.
+     * @param timeIn Time, in seconds.
      * @param toFormat The string to format. Should contain one or more format specifiers with argument indexes
      *                 corresponding to seconds, minutes, and hours, respectively.
      * @return The formatted string.
      * */
-    public String formatTime(int time, String toFormat) {
-        int seconds = (time % 60);
-        int minutes = (time % 3600) / 60;
-        int hours = time / 3600;
+    public String formatTime(final int timeIn, final String toFormat) {
+        final int secondsInMinute = 60;
+        final int secondsInHour = 3600;
+        final int seconds = (timeIn % secondsInMinute);
+        final int minutes = (timeIn % secondsInHour) / secondsInMinute;
+        final int hours = timeIn / secondsInHour;
         return String.format(toFormat, seconds, minutes, hours);
     }
 
@@ -346,13 +350,14 @@ public class CellUnderAttack extends Cell {
             new CellAttackThread(this),
             this.flagPhaseInterval,
             this.flagPhaseInterval);
+        final long ticksInSecond = 20L;
         if (FlagWarConfig.isHologramEnabled()) {
             drawHologram();
             if (FlagWarConfig.hasTimerLine()) {
                 hologramThread = towny.getServer().getScheduler().scheduleSyncRepeatingTask(towny,
                     new HologramUpdateThread(this),
-                    20L,
-                    20L);
+                    ticksInSecond,
+                    ticksInSecond);
             }
         }
     }
@@ -370,7 +375,9 @@ public class CellUnderAttack extends Cell {
             towny.getServer().getScheduler().cancelTask(hologramThread);
         }
         destroyFlag();
-        if (hologram != null) { destroyHologram(); }
+        if (hologram != null) {
+            destroyHologram();
+        }
     }
 
     /** @return the string "%getWorldName% (%getX%, %getZ%)". */

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -76,6 +76,29 @@ timer_blocks:
         - orange_terracotta
         - red_terracotta
 
+# Defines War Flag Hologram settings
+# Requires HolographicDisplays
+holograms:
+    # If true, and if HolographicDisplays is present, holograms will appear when a war flag is placed.
+    enabled: false
+    # Defines the lines of the hologram. The number indicates the line number. Starts at zero.
+    # Use an item type to add a floating item.
+    # Use a text type to add text.
+    # Use the timer type to indicate the time left. Only one timer line may be used.
+    # The timer formatting can be customised as described here:
+    # https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/util/Formatter.html
+    # Argument Index: Seconds is the first argument, minutes the second argument, and hours the third argument.
+    lines:
+        0:
+            type: item
+            data: DIAMOND_SWORD
+        1:
+            type: text
+            data: "&c&lWar Flag"
+        2:
+            type: timer
+            data: "&aTime Left: %2$d:%1$02d"
+
 # Define Beacon Structure
 beacon:
     draw: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -16,5 +16,8 @@ prefix: FlagWar
 
 description: ${description}
 
+softdepend:
+    - HolographicDisplays
+
 depend:
     - Towny


### PR DESCRIPTION
#### Brief Description:
<!-- Describe your Pull Request's purpose here please. --->
Adds configurable holograms that spawn above war flags. The hologram is defined by lines. There are four line types: item, text, timer, and empty. Item lines are floating items. Empty and text lines are self explanatory. Most notably, timer lines can be used to show the time remaining on a war flag, a great QOL feature, and especially useful if you might be using alternative timer materials. Color codes are supported in all text, and the formatting of the timer is extremely customisable.
<details>
  <summary>Demo (GIF)</summary>
  
  ![hologram](https://user-images.githubusercontent.com/38970841/125621793-1c2583ad-16a1-4d9b-85f8-71407104ae36.gif)

</details>

____
#### Changes:
<!-- 
Please state your changes in human-readable format if the Description isn't enough detail. Small PRs
can usually ignore this section, or remove it. However, fairly sized PRs (such as a class rewrite)
should go into detail about the changes here.
-->
## Changes in FlagWarConfig.java
* Add boolean #isHologramEnabled
  * Used to cache result of #isHologramEnabled(boolean checkConfig)
  * Returned by #isHologramEnabled()
* Add #HOLOGRAM_SETTINGS
  * Stores parsed hologram settings from config
  * Checks value of #isHologramEnabled via #isHologramEnabled()
    * If true, is set to #getHologramConfig()
    * If false, is set to null
  * Returned by #getHologramSettings
* Add boolean #hasTimerLine
  * Returned by #hasTimerLine()
  * Set in #getHologramConfig()
  * True if the hologram has a timer line
* Add string #timerText
  * Returned by #getTimerText()
  * Set in #getHologramConfig()
  * Stores text of hologram timer line, if any
* Add #isHologramEnabled(boolean checkConfig)
  * Parameter does nothing, just an overload
  * Checks if holograms are enabled in config, and HolographicDisplays is present, returns true if both conditions are met
* Add #isHologramEnabled()
  * Returns #isHologramEnabled
* Add #getHologramConfig()
  * Parses hologram line configuration
  * Validates type and data of each line
  * Error handling for empty lines/no lines configured
  * Sets #hasTimerLine, #timerText if a valid timer line is parsed
  * Returns hologram settings list
  * data is passed through Colors#translateColorCodes() to parse color codes
* Add #setEmpty(List list, int i)
  * Utility for #getHologramConfig()
  * If the line is first, just ignore it & log
  * Otherwise, set empty, log
* Add #getHologramSettings()
  * Returns #HOLOGRAM_SETTINGS
* Add #getTimerText()
  * Returns #timerText
* Add #hasTimerLine()
  * Returns #hasTimerLine

## Changes in CellUnderAttack.java
* Add int #hologramThread
  * Stores integer of hologram update task
  * Set in #beginAttack()
* Add Hologram #hologram
  * Stores war flag Hologram instance
  * Set in #drawHologram()
* Add int #time
  * Stores remaining war flag time, assuming 20 ticks = 1s
  * Set in constructor
* Add TextLine #timerLine
  * Stores the TextLine of the hologram timer line
  * Used to update the timer
* Changes in constructor
  * Set hologramThread to -1
  * Get war flag time from config
* Add #drawHologram()
  * Fetches hologram settings via FlagWarConfig#getHologramSettings()
  * Creates #hologram based on hologram settings
  * Hologram is only shown after it's created to prevent a visual shift before the correct location can be set based on the hologram height
* Add #updateHologram()
  * Decrement #time by 1s
  * Update #timerLine with new #time using #formatTime(int time, String toFormat)
* Add #destroyHologram()
  * Deletes #hologram
* Add #formatTime(int time, String toFormat)
  * Get seconds, minutes, hours based on remaining #time
  * Return inputted string formatted with seconds, muntes, hours
* Changes in #beginAttack()
  * Check FlagWarConfig#isHologramEnabled()
    * If true, call #drawHologram()
    * Check FlagWarConfig#hasTimerLine()
      * If true, start #hologramThread with a new HologramUpdateThread with a 20 tick (1s) repeat delay and runtime timer.
* Changes in #cancel()
  * If there is a running #hologramThread, cancel the task
  * If there is an active hologram, call #destroyHologram()

## Add HologramUpdateThread.java
* Task to update a cell's hologram, if it has a timer
* Just calls CellUnderAttack#updateHologram()

## Changes in config.yml
* Add holograms.enabled
  * If true, holograms will be enabled (provided HolographicDisplays is present)
* Add holograms.lines
  * Config for hologram lines
  * Keys are line index, starting at zero
  * Each index then has type and data keys
  * Types:
    * item: data should be a Material, the provided Material will appear as a floating item
    * text: simple text line from data string, supports color codes
    * timer: a line that shows the remaining war flag time
      * Uses Java string formatting to display the time
      * Order of arguments are: seconds, minutes, hours
      * Default timer formatting is intended for war flag times above 1m and below 1h. Thus, should be fine for typical user.
      * Also supports color codes
    * empty: just an empty line

## Changes in plugin.yml
* Add softdepend for HolographicDisplays

## Changes in pom.xml
* Add holographicdisplays-api dependency

____
#### Relevant FlagWar Issue tickets:
<!--
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
If you add issues manually on the sidebar, you can safely delete this heading. If using keywords,
please use an unordered list should you need to reference more than one issue.
--->
Closes #19 

____
- [x] I have tested this pull request for defects on a server.
<!-- Replace `[ ]` with `[x]` if completed. --->

---
By making this pull request, I represent that I have read and agree to release my own changes that I
have submitted under the terms of the accompanying license (Apache-2.0). I guarantee that these
changes are mine and are not encumbered by any other license or restriction to the best of my
knowledge.

<!-- For co-authored commits, all co-authors will need to reply to this PR within a 48 Hrs.
If no replies have been left within a reasonable period, we may attempt to contact them by their
email tied to their commits, OR reject the PR at our discretion.

For Co-authoring docs, see:
https://docs.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors
--->