### PR TITLE
Feature: Add OutlawListener, cancel OutlawTeleportEvents; API: Add isUnderAttack(Nation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ Latest first.
 
 ## STAGING
 
+### Additions
+- Add `FlagWarAPI#isUnderAttack(Nation)`
+  - Returns true if any town in the supplied nation contains a cell under attack.
+
 ### Misc. Changes
+- Bump Towny API dependency to 0.97.0.17; set as Min_Towny_Version
+- Bump Config Version to 1.3 (Post 0.3.0... Woopsie.)
 - Removed unnecessary deployment to GitHub Packages
 
 ## 0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Latest first.
   - Returns true if any town in the supplied nation contains a cell under attack.
 - Add `OutlawListener` and listen for the `OutlawTeleportEvent`
   - Outlaws cannot teleport away during an attack while in enemy territory or enemy nation zone during a war.
+  - Add `error.outlaw.cannot-teleport-here` translation key, sent to the outlaw.
 
 ### Misc. Changes
 - Bump Towny API dependency to 0.97.0.17; set as Min_Towny_Version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Latest first.
 - Add `FlagWarAPI#isUnderAttack(Nation)`
   - Returns true if any town in the supplied nation contains a cell under attack.
 - Add `OutlawListener` and listen for the `OutlawTeleportEvent`
-  - Outlaws cannot teleport away during an attack while in enemy territory or enemy nation zone during a war.
+  - Outlaws cannot be teleported away during an attack while in enemy territory (or enemy nation zone) during an active
+  war.
   - Add `error.outlaw.cannot-teleport-here` translation key, sent to the outlaw.
 
 ### Misc. Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Latest first.
 ### Additions
 - Add `FlagWarAPI#isUnderAttack(Nation)`
   - Returns true if any town in the supplied nation contains a cell under attack.
+- Add `OutlawListener` and listen for the `OutlawTeleportEvent`
+  - Outlaws cannot teleport away during an attack while in enemy territory or enemy nation zone during a war.
 
 ### Misc. Changes
 - Bump Towny API dependency to 0.97.0.17; set as Min_Towny_Version

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.townyadvanced.flagwar</groupId>
     <artifactId>FlagWar</artifactId>
     <packaging>jar</packaging>
-    <version>0.3.0</version>
+    <version>0.3.1-SNAPSHOT</version>
     <description>An OG war system for TownyAdvanced. Celebrating a decade of Flag-based Towny Warfare.</description>
 
     <properties>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.github.TownyAdvanced</groupId>
             <artifactId>Towny</artifactId>
-            <version>0.97.0.12</version>
+            <version>0.97.0.17</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/github/townyadvanced/flagwar/FlagWar.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/FlagWar.java
@@ -82,9 +82,9 @@ public class FlagWar extends JavaPlugin {
     /** FlagWar Copyright String. */
     private static final String FW_COPYRIGHT = "Copyright \u00a9 2021 TownyAdvanced";
     /** Version object for storing the minimum required version of Towny for compatibility. */
-    private static final Version MIN_TOWNY_VER = Version.fromString("0.97.0.5");
+    private static final Version MIN_TOWNY_VER = Version.fromString("0.97.0.17");
     /** Value of minimum configuration file version. Used for determining if file should be regenerated. */
-    private static final double MIN_CONFIG_VER = 1.2;
+    private static final double MIN_CONFIG_VER = 1.3;
     /** BStats Metrics ID. */
     public static final int METRICS_ID = 10325;
     /** Holds FlagWar's Bukkit-assigned JUL {@link Logger}. */

--- a/src/main/java/io/github/townyadvanced/flagwar/FlagWar.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/FlagWar.java
@@ -44,6 +44,7 @@ import io.github.townyadvanced.flagwar.listeners.FlagWarBlockListener;
 import io.github.townyadvanced.flagwar.listeners.FlagWarCustomListener;
 import io.github.townyadvanced.flagwar.listeners.FlagWarEntityListener;
 import io.github.townyadvanced.flagwar.listeners.WarzoneListener;
+import io.github.townyadvanced.flagwar.listeners.OutlawListener;
 import io.github.townyadvanced.flagwar.objects.Cell;
 import io.github.townyadvanced.flagwar.objects.CellUnderAttack;
 
@@ -101,6 +102,8 @@ public class FlagWar extends JavaPlugin {
     private FlagWarEntityListener flagWarEntityListener;
     /** Holds instance of the {@link WarzoneListener}. */
     private WarzoneListener warzoneListener;
+    /** Holds instance of the {@link OutlawListener}. */
+    private OutlawListener outlawListener;
 
     /**
      * Operations to perform when called by {@link org.bukkit.plugin.PluginLoader#enablePlugin(Plugin)}.
@@ -200,6 +203,7 @@ public class FlagWar extends JavaPlugin {
         PLUGIN_MANAGER.registerEvents(flagWarCustomListener, this);
         PLUGIN_MANAGER.registerEvents(flagWarEntityListener, this);
         PLUGIN_MANAGER.registerEvents(warzoneListener, this);
+        PLUGIN_MANAGER.registerEvents(outlawListener, this);
         FW_LOGGER.log(Level.INFO, () -> Translate.from("startup.events.registered"));
     }
 
@@ -210,6 +214,7 @@ public class FlagWar extends JavaPlugin {
         flagWarCustomListener = new FlagWarCustomListener(this);
         flagWarEntityListener = new FlagWarEntityListener();
         warzoneListener = new WarzoneListener();
+        outlawListener = new OutlawListener();
         FW_LOGGER.log(Level.INFO, () -> Translate.from("startup.listeners.initialized"));
     }
 

--- a/src/main/java/io/github/townyadvanced/flagwar/FlagWarAPI.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/FlagWarAPI.java
@@ -17,6 +17,7 @@
 
 package io.github.townyadvanced.flagwar;
 
+import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import io.github.townyadvanced.flagwar.config.FlagWarConfig;
 import io.github.townyadvanced.flagwar.objects.Cell;
@@ -49,6 +50,21 @@ public final class FlagWarAPI {
      */
     public static boolean isUnderAttack(final Town town) {
         return FlagWar.isUnderAttack(town);
+    }
+
+    /**
+     * Check if a {@link Nation} is under attack by iterating over each of its member Towns.
+     * @param nation Target Nation to check.
+     * @return True if there is a {@link CellUnderAttack} in any of the supplied Nation's towns.
+     */
+    public static boolean isUnderAttack(final Nation nation) {
+        boolean nationUnderAttack = false;
+        for (Town town : nation.getTowns()) {
+            if (FlagWarAPI.isUnderAttack(town)) {
+                nationUnderAttack = true;
+            }
+        }
+        return nationUnderAttack;
     }
 
     /**

--- a/src/main/java/io/github/townyadvanced/flagwar/listeners/OutlawListener.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/listeners/OutlawListener.java
@@ -19,12 +19,10 @@ package io.github.townyadvanced.flagwar.listeners;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.event.teleport.OutlawTeleportEvent;
 import com.palmergames.bukkit.towny.object.Nation;
-import com.palmergames.bukkit.towny.object.PlayerCache;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import io.github.townyadvanced.flagwar.FlagWarAPI;
 import io.github.townyadvanced.flagwar.util.Messaging;
-import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -57,8 +55,8 @@ public class OutlawListener implements Listener {
         if (townAtLocation != null) {
             nationOfLocation = townAtLocation.getNationOrNull();
         } else {
-            // Town is null, need to check if we're in a Nation Zone
-            if (!isNationZone(outlawLocation) || locTownBlock == null) {
+            // Town is null, return if not a NationZone or if the locTownBlock is null
+            if (!TownyAPI.getInstance().isNationZone(outlawLocation) || locTownBlock == null) {
                 return;
             }
             nationOfLocation = getClosestNation(locTownBlock);
@@ -99,24 +97,6 @@ public class OutlawListener implements Listener {
             return null;
         }
         return closestTown.getNationOrNull();
-    }
-
-    /**
-     * Checks the {@link com.palmergames.bukkit.towny.object.PlayerCache.TownBlockStatus} of a given {@link Location}
-     * and returns TRUE if that location would be considered a NATION_ZONE.
-     *
-     * Self-integrates an isWilderness check, which will return false on failure.
-     *
-     * @param location the Location needing to be checked.
-     * @return True, if the isWilderness check passes, and if the TownBlockStatus is equal to
-     *         {@link com.palmergames.bukkit.towny.object.PlayerCache.TownBlockStatus#NATION_ZONE}.
-     */
-    private boolean isNationZone(final Location location) {
-        if (!TownyAPI.getInstance().isWilderness(location)) {
-            return false;
-        }
-        var blockStatus = TownyAPI.getInstance().hasNationZone(location);
-        return blockStatus.equals(PlayerCache.TownBlockStatus.NATION_ZONE);
     }
 }
 

--- a/src/main/java/io/github/townyadvanced/flagwar/listeners/OutlawListener.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/listeners/OutlawListener.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2021 TownyAdvanced
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.github.townyadvanced.flagwar.listeners;
+
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.event.teleport.OutlawTeleportEvent;
+import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.object.PlayerCache;
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.TownBlock;
+import io.github.townyadvanced.flagwar.FlagWarAPI;
+import io.github.townyadvanced.flagwar.util.Messaging;
+import org.bukkit.Location;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * {@link Listener} class for Outlaw-related events and balancing.
+ * @author FlagCourier
+ */
+public class OutlawListener implements Listener {
+
+    /**
+     * Listens to the OutlawTeleportEvent, then cancels it if the appropriate conditions are met.
+     * @param event {@link OutlawTeleportEvent} thrown by Towny.
+     */
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onOutlawTeleport(final OutlawTeleportEvent event) {
+        if (event.getOutlaw().getPlayer() == null) {
+            return;
+        }
+
+        var outlaw = event.getOutlaw();
+        var outlawNation = outlaw.getNationOrNull();
+        var outlawLocation = event.getOutlawLocation();
+        var locTownBlock = TownyAPI.getInstance().getTownBlock(outlawLocation);
+        var townAtLocation = TownyAPI.getInstance().getTownOrNull(locTownBlock);
+        Nation nationOfLocation;
+
+        // Assign nationOfLocation to either the Nation of the townAtLocation, or the next nearest Nation.
+        if (townAtLocation != null) {
+            nationOfLocation = townAtLocation.getNationOrNull();
+        } else {
+            // Town is null, need to check if we're in a Nation Zone
+            if (!isNationZone(outlawLocation) || locTownBlock == null) {
+                return;
+            }
+            nationOfLocation = getClosestNation(locTownBlock);
+        }
+
+        // Ignore if we cannot get the (nearest) nation. This should only happen on worlds without claims.
+        if (nationOfLocation == null) {
+            Messaging.debug("Outlaw Teleport Not Canceled: nationOfLocation is NULL");
+            return;
+        }
+
+        // Ignore if [own|allied] nation lands. (Skipped if outlaw does not have a nation.)
+        if (outlawNation != null && (outlawNation.equals(nationOfLocation) || outlawNation.hasAlly(nationOfLocation))) {
+            Messaging.debug("Outlaw Teleport Not Canceled: Own / Allied Nation Area.");
+            return;
+        }
+
+        // Require location to be under attack, and for appropriate outlaw association.
+        if (FlagWarAPI.isUnderAttack(nationOfLocation) && nationOfLocation.getOutlaws().contains(outlaw)) {
+            Messaging.debug("Outlawed Player Teleport Canceled");
+            event.setCancelled(true);
+        }
+    }
+
+    /**
+     * Get the closest nation from a supplied {@link TownBlock}, or null.
+     * @param townBlock The supplied TownBlock.
+     * @return The closest Nation, or null if there is not a next closest town block with a nation in the same world.
+     */
+    @Nullable
+    private Nation getClosestNation(final TownBlock townBlock) {
+        var closestNatTB = townBlock.getWorld().getClosestTownblockWithNationFromCoord(townBlock.getCoord());
+        Town closestTown = null;
+        if (closestNatTB != null) {
+            closestTown = closestNatTB.getTownOrNull();
+        }
+        if (closestTown == null) {
+            return null;
+        }
+        return closestTown.getNationOrNull();
+    }
+
+    /**
+     * Checks the {@link com.palmergames.bukkit.towny.object.PlayerCache.TownBlockStatus} of a given {@link Location}
+     * and returns TRUE if that location would be considered a NATION_ZONE.
+     *
+     * Self-integrates an isWilderness check, which will return false on failure.
+     *
+     * @param location the Location needing to be checked.
+     * @return True, if the isWilderness check passes, and if the TownBlockStatus is equal to
+     *         {@link com.palmergames.bukkit.towny.object.PlayerCache.TownBlockStatus#NATION_ZONE}.
+     */
+    private boolean isNationZone(final Location location) {
+        if (!TownyAPI.getInstance().isWilderness(location)) {
+            return false;
+        }
+        var blockStatus = TownyAPI.getInstance().hasNationZone(location);
+        return blockStatus.equals(PlayerCache.TownBlockStatus.NATION_ZONE);
+    }
+}
+

--- a/src/main/java/io/github/townyadvanced/flagwar/listeners/OutlawListener.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/listeners/OutlawListener.java
@@ -22,6 +22,7 @@ import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import io.github.townyadvanced.flagwar.FlagWarAPI;
+import io.github.townyadvanced.flagwar.i18n.Translate;
 import io.github.townyadvanced.flagwar.util.Messaging;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -51,7 +52,7 @@ public class OutlawListener implements Listener {
         var townAtLocation = TownyAPI.getInstance().getTownOrNull(locTownBlock);
         Nation nationOfLocation;
 
-        // Assign nationOfLocation to either the Nation of the townAtLocation, or the next nearest Nation.
+        // Assign nationOfLocation to either the Nation of the townAtLocation, or the nearest Nation.
         if (townAtLocation != null) {
             nationOfLocation = townAtLocation.getNationOrNull();
         } else {
@@ -76,6 +77,8 @@ public class OutlawListener implements Listener {
 
         // Require location to be under attack, and for appropriate outlaw association.
         if (FlagWarAPI.isUnderAttack(nationOfLocation) && nationOfLocation.getOutlaws().contains(outlaw)) {
+            Messaging.send(outlaw.getPlayer(),
+                Translate.fromPrefixed("error.outlaw.cannot-teleport-here", nationOfLocation.toString()));
             Messaging.debug("Outlawed Player Teleport Canceled");
             event.setCancelled(true);
         }

--- a/src/main/java/io/github/townyadvanced/flagwar/listeners/OutlawListener.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/listeners/OutlawListener.java
@@ -36,7 +36,9 @@ import org.jetbrains.annotations.Nullable;
 public class OutlawListener implements Listener {
 
     /**
-     * Listens to the OutlawTeleportEvent, then cancels it if the appropriate conditions are met.
+     * Listens to the {@link OutlawTeleportEvent}, then cancels it if the appropriate conditions are met.
+     * Typically, the event should only ever be fired when an outlaw would attempt to enter a town that has barred them,
+     * and therefore acts similar to a border-patrol.
      * @param event {@link OutlawTeleportEvent} thrown by Towny.
      */
     @EventHandler(priority = EventPriority.LOWEST)
@@ -63,7 +65,7 @@ public class OutlawListener implements Listener {
             nationOfLocation = getClosestNation(locTownBlock);
         }
 
-        // Ignore if we cannot get the (nearest) nation. This should only happen on worlds without claims.
+        // Ignore if we cannot get the (nearest) nation. This should never happen when this event is fired.
         if (nationOfLocation == null) {
             Messaging.debug("Outlaw Teleport Not Canceled: nationOfLocation is NULL");
             return;
@@ -78,8 +80,8 @@ public class OutlawListener implements Listener {
         // Require location to be under attack, and for appropriate outlaw association.
         if (FlagWarAPI.isUnderAttack(nationOfLocation) && nationOfLocation.getOutlaws().contains(outlaw)) {
             Messaging.send(outlaw.getPlayer(),
-                Translate.fromPrefixed("error.outlaw.cannot-teleport-here", nationOfLocation.toString()));
-            Messaging.debug("Outlawed Player Teleport Canceled");
+                Translate.fromPrefixed("message.outlaw.bypass-outlaw-teleport-event", nationOfLocation.toString()));
+            Messaging.debug(String.format("Outlawed Player (%s) Teleport Canceled", outlaw.getName()));
             event.setCancelled(true);
         }
     }

--- a/src/main/resources/Translation_en_GB.properties
+++ b/src/main/resources/Translation_en_GB.properties
@@ -63,3 +63,4 @@ error.target-is-peaceful=&c%s is peaceful.
 error.warzone.cannot-edit=&cCannot %s %s in a Warzone.
 error.warzone.cannot-use-item=&cCannot use this item in a Warzone.
 error.warzone.cannot-use-switch=&cCannot use switches in a Warzone.
+error.outlaw.cannot-teleport-here=&cYou cannot teleport here due to being outlawed by the %s nation!

--- a/src/main/resources/Translation_en_GB.properties
+++ b/src/main/resources/Translation_en_GB.properties
@@ -63,4 +63,4 @@ error.target-is-peaceful=&c%s is peaceful.
 error.warzone.cannot-edit=&cCannot %s %s in a Warzone.
 error.warzone.cannot-use-item=&cCannot use this item in a Warzone.
 error.warzone.cannot-use-switch=&cCannot use switches in a Warzone.
-error.outlaw.cannot-teleport-here=&cYou cannot teleport here due to being outlawed by the %s nation!
+message.outlaw.bypass-outlaw-teleport-event=&cYou have entered %s as a member of an invading force.

--- a/src/main/resources/Translation_en_US-POSIX.properties
+++ b/src/main/resources/Translation_en_US-POSIX.properties
@@ -63,3 +63,4 @@ error.target-is-peaceful=&c%s is peaceful.
 error.warzone.cannot-edit=&cCannot %s %s in a Warzone.
 error.warzone.cannot-use-item=&cCannot use this item in a Warzone.
 error.warzone.cannot-use-switch=&cCannot use switches in a Warzone.
+error.outlaw.cannot-teleport-here=&cYou cannot teleport here due to being outlawed by the %s nation!

--- a/src/main/resources/Translation_en_US-POSIX.properties
+++ b/src/main/resources/Translation_en_US-POSIX.properties
@@ -63,4 +63,4 @@ error.target-is-peaceful=&c%s is peaceful.
 error.warzone.cannot-edit=&cCannot %s %s in a Warzone.
 error.warzone.cannot-use-item=&cCannot use this item in a Warzone.
 error.warzone.cannot-use-switch=&cCannot use switches in a Warzone.
-error.outlaw.cannot-teleport-here=&cYou cannot teleport here due to being outlawed by the %s nation!
+message.outlaw.bypass-outlaw-teleport-event=&cYou have entered %s as a member of an invading force.

--- a/src/main/resources/Translation_en_US.properties
+++ b/src/main/resources/Translation_en_US.properties
@@ -63,3 +63,4 @@ error.target-is-peaceful=&c%s is peaceful.
 error.warzone.cannot-edit=&cCannot %s %s in a Warzone.
 error.warzone.cannot-use-item=&cCannot use this item in a Warzone.
 error.warzone.cannot-use-switch=&cCannot use switches in a Warzone.
+error.outlaw.cannot-teleport-here=&cYou cannot teleport here due to being outlawed by the %s nation!

--- a/src/main/resources/Translation_en_US.properties
+++ b/src/main/resources/Translation_en_US.properties
@@ -63,4 +63,4 @@ error.target-is-peaceful=&c%s is peaceful.
 error.warzone.cannot-edit=&cCannot %s %s in a Warzone.
 error.warzone.cannot-use-item=&cCannot use this item in a Warzone.
 error.warzone.cannot-use-switch=&cCannot use switches in a Warzone.
-error.outlaw.cannot-teleport-here=&cYou cannot teleport here due to being outlawed by the %s nation!
+message.outlaw.bypass-outlaw-teleport-event=&cYou have entered %s as a member of an invading force.

--- a/src/main/resources/Translation_en_US_POSIX.properties
+++ b/src/main/resources/Translation_en_US_POSIX.properties
@@ -63,3 +63,4 @@ error.target-is-peaceful=&c%s is peaceful.
 error.warzone.cannot-edit=&cCannot %s %s in a Warzone.
 error.warzone.cannot-use-item=&cCannot use this item in a Warzone.
 error.warzone.cannot-use-switch=&cCannot use switches in a Warzone.
+error.outlaw.cannot-teleport-here=&cYou cannot teleport here due to being outlawed by the %s nation!

--- a/src/main/resources/Translation_en_US_POSIX.properties
+++ b/src/main/resources/Translation_en_US_POSIX.properties
@@ -63,4 +63,4 @@ error.target-is-peaceful=&c%s is peaceful.
 error.warzone.cannot-edit=&cCannot %s %s in a Warzone.
 error.warzone.cannot-use-item=&cCannot use this item in a Warzone.
 error.warzone.cannot-use-switch=&cCannot use switches in a Warzone.
-error.outlaw.cannot-teleport-here=&cYou cannot teleport here due to being outlawed by the %s nation!
+message.outlaw.bypass-outlaw-teleport-event=&cYou have entered %s as a member of an invading force.

--- a/src/main/resources/Translation_es_MX.properties
+++ b/src/main/resources/Translation_es_MX.properties
@@ -63,3 +63,4 @@ error.target-is-peaceful=&c%s is peaceful.
 error.warzone.cannot-edit=&cCannot %s %s in a Warzone.
 error.warzone.cannot-use-item=&cCannot use this item in a Warzone.
 error.warzone.cannot-use-switch=&cCannot use switches in a Warzone.
+error.outlaw.cannot-teleport-here=&cYou cannot teleport here due to being outlawed by the %s nation!

--- a/src/main/resources/Translation_es_MX.properties
+++ b/src/main/resources/Translation_es_MX.properties
@@ -63,4 +63,4 @@ error.target-is-peaceful=&c%s is peaceful.
 error.warzone.cannot-edit=&cCannot %s %s in a Warzone.
 error.warzone.cannot-use-item=&cCannot use this item in a Warzone.
 error.warzone.cannot-use-switch=&cCannot use switches in a Warzone.
-error.outlaw.cannot-teleport-here=&cYou cannot teleport here due to being outlawed by the %s nation!
+message.outlaw.bypass-outlaw-teleport-event=&cYou have entered %s as a member of an invading force.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -16,7 +16,7 @@
 ################################################################################
 
 # Note: Do not modify config_version, unless you want to regenerate your config
-config_version: 1.2
+config_version: 1.3
 
 # Please see https://github.com/TownyAdvanced/FlagWar/tree/main/src/main/resources/
 # for available translations. Custom translations are only supported if they are merged.


### PR DESCRIPTION
#### Brief Description:
<!-- Describe your Pull Request's purpose here please. --->
Adds an new `OutlawListener` class that listens to the Towny `OutlawTeleportEvent`.
Also, adds `FlagWarAPI#isUnderAttack(Nation)`.
____
#### Changes:
<!-- 
Please state your changes in human-readable format if the Description isn't enough detail. Small PRs
can usually ignore this section, or remove it. However, fairly sized PRs (such as a class rewrite)
should go into detail about the changes here.
-->
 If an outlawed player is in enemy territory, while the said enemy is under attack, the event should be canceled to prevent escape. This should also come into effect if the player is within an enemy's NationZone. If the event is fired, while the outlawed player is within their own territory, or an allies,  the event will *not* be canceled.

The outlaw is only notified when they cannot teleport.

This can be extended in the future with configurable switches (such as allowing cancellation regardless of who owns the territory, or if this listener should be disabled all together.)

____
#### Relevant FlagWar Issue tickets:
<!--
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
If you add issues manually on the sidebar, you can safely delete this heading. If using keywords,
please use an unordered list should you need to reference more than one issue.
--->
Closes #60 
____
- [x] I have tested this pull request for defects on a server.
<!-- Replace `[ ]` with `[x]` if completed. --->

---
By making this pull request, I represent that I have read and agree to release my own changes that I
have submitted under the terms of the accompanying license (Apache-2.0). I guarantee that these
changes are mine and are not encumbered by any other license or restriction to the best of my
knowledge.

<!-- For co-authored commits, all co-authors will need to reply to this PR within a 48 Hrs.
If no replies have been left within a reasonable period, we may attempt to contact them by their
email tied to their commits, OR reject the PR at our discretion.

For Co-authoring docs, see:
https://docs.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors
--->
