### PR TITLE
Adds new option to the config to unclaim won townblocks.

### DIFF
--- a/src/main/java/io/github/townyadvanced/flagwar/config/FlagWarConfig.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/config/FlagWarConfig.java
@@ -444,4 +444,9 @@ public final class FlagWarConfig {
     public static boolean isFlaggedTownBlockTransferred() {
         return PLUGIN.getConfig().getBoolean("rules.flag_takes_ownership_of_town_blocks");
     }
+
+    /** @return the value of 'rules.flag_unclaims_townblocks'. */
+    public static boolean isFlaggedTownBlockUnclaimed() {
+        return PLUGIN.getConfig().getBoolean("rules.flag_unclaims_townblocks");
+    }
 }

--- a/src/main/java/io/github/townyadvanced/flagwar/listeners/FlagWarCustomListener.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/listeners/FlagWarCustomListener.java
@@ -426,9 +426,9 @@ public class FlagWarCustomListener implements Listener {
     }
 
     private void transferOrUnclaimOrKeepTownblock(final Town atkTown, final TownBlock townBlock, final Town defTown) {
-        if (FlagWarConfig.isFlaggedTownBlockUnclaimed())
+        if (FlagWarConfig.isFlaggedTownBlockUnclaimed()) {
             unclaimTownBlock(townBlock);
-        else if (FlagWarConfig.isFlaggedTownBlockTransferred()) {
+        } else if (FlagWarConfig.isFlaggedTownBlockTransferred()) {
             transferOwnership(atkTown, townBlock);
         } else {
             String message = Translate.fromPrefixed("area.won.defender-keeps-claims");

--- a/src/main/java/io/github/townyadvanced/flagwar/listeners/FlagWarCustomListener.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/listeners/FlagWarCustomListener.java
@@ -193,7 +193,7 @@ public class FlagWarCustomListener implements Listener {
             }
 
             // Defender loses townblock
-            transferOrKeepTownblock(attackingTown, townBlock, defendingTown);
+            transferOrUnclaimOrKeepTownblock(attackingTown, townBlock, defendingTown);
 
             // Cleanup
             towny.updateCache(worldCoord);
@@ -425,8 +425,10 @@ public class FlagWarCustomListener implements Listener {
             return total;
     }
 
-    private void transferOrKeepTownblock(final Town atkTown, final TownBlock townBlock, final Town defTown) {
-        if (FlagWarConfig.isFlaggedTownBlockTransferred()) {
+    private void transferOrUnclaimOrKeepTownblock(final Town atkTown, final TownBlock townBlock, final Town defTown) {
+        if (FlagWarConfig.isFlaggedTownBlockUnclaimed())
+            unclaimTownBlock(townBlock);
+        else if (FlagWarConfig.isFlaggedTownBlockTransferred()) {
             transferOwnership(atkTown, townBlock);
         } else {
             String message = Translate.fromPrefixed("area.won.defender-keeps-claims");
@@ -464,6 +466,10 @@ public class FlagWarCustomListener implements Listener {
         } else {
             return "Townblock";
         }
+    }
+
+    private void unclaimTownBlock(final TownBlock townBlock) {
+        TownyUniverse.getInstance().getDataSource().removeTownBlock(townBlock);
     }
 
     private void transferOwnership(final Town attackingTown, final TownBlock townBlock) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -33,7 +33,11 @@ rules:
     # Force attackers to only attack edge plots.
     only_attack_borders: true
 
+    # False: Attackers capture plots when they win. Disable if you prefer *not* dealing with that.
+    flag_unclaims_townblocks: false
+
     # True: Attackers capture plots when they win. Disable if you prefer *not* dealing with that.
+    # This has no effect if flag_unclaims_townblocks is true.
     flag_takes_ownership_of_town_blocks: true
 
     # Will prevent players from performing certain actions while a town is flagged or is in cool-down.


### PR DESCRIPTION
#### Brief Description:
<!-- Describe your Pull Request's purpose here please. --->
New Config option:
```
    # False: Attackers capture plots when they win. Disable if you
prefer *not* dealing with that.
    flag_unclaims_townblocks: false
```
____
#### Changes:
<!-- 
Please state your changes in human-readable format if the Description isn't enough detail. Small PRs
can usually ignore this section, or remove it. However, fairly sized PRs (such as a class rewrite)
should go into detail about the changes here.
-->
Adds a third option for unclaiming, which will take precedent over the `flag_takes_ownership_of_town_blocks: true` option, by modifying this event:
```java
    private void transferOrUnclaimOrKeepTownblock(final Town atkTown, final TownBlock townBlock, final Town defTown) {
        if (FlagWarConfig.isFlaggedTownBlockUnclaimed())
            unclaimTownBlock(townBlock);
        else if (FlagWarConfig.isFlaggedTownBlockTransferred()) {
            transferOwnership(atkTown, townBlock);
        } else {
            String message = Translate.fromPrefixed("area.won.defender-keeps-claims");
            TownyMessaging.sendPrefixedTownMessage(atkTown, message);
            TownyMessaging.sendPrefixedTownMessage(defTown, message);
        }
    }
```
The comments of the overriden config option have been modified to explicitly state it does nothing if the unclaim option is true.

____
#### Relevant FlagWar Issue tickets:
<!--
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
If you add issues manually on the sidebar, you can safely delete this heading. If using keywords,
please use an unordered list should you need to reference more than one issue.
--->
Closes #71.
____
- [ ] I have tested this pull request for defects on a server.
<!-- Replace `[ ]` with `[x]` if completed. --->

---
By making this pull request, I represent that I have read and agree to release my own changes that I
have submitted under the terms of the accompanying license (Apache-2.0). I guarantee that these
changes are mine and are not encumbered by any other license or restriction to the best of my
knowledge.

<!-- For co-authored commits, all co-authors will need to reply to this PR within a 48 Hrs.
If no replies have been left within a reasonable period, we may attempt to contact them by their
email tied to their commits, OR reject the PR at our discretion.

For Co-authoring docs, see:
https://docs.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors
--->
