### PR TITLE
Fix NPE in OutlawListener

### DIFF
--- a/src/main/java/io/github/townyadvanced/flagwar/listeners/OutlawListener.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/listeners/OutlawListener.java
@@ -51,7 +51,7 @@ public class OutlawListener implements Listener {
         var outlawNation = outlaw.getNationOrNull();
         var outlawLocation = event.getOutlawLocation();
         var locTownBlock = TownyAPI.getInstance().getTownBlock(outlawLocation);
-        var townAtLocation = TownyAPI.getInstance().getTownOrNull(locTownBlock);
+        var townAtLocation = TownyAPI.getInstance().getTown(outlawLocation);
         Nation nationOfLocation;
 
         // Assign nationOfLocation to either the Nation of the townAtLocation, or the nearest Nation.


### PR DESCRIPTION
#### Brief Description:
<!-- Describe your Pull Request's purpose here please. --->

Gathering the town using a null townblock threw an NPE.

____
#### Changes:
<!-- 
Please state your changes in human-readable format if the Description isn't enough detail. Small PRs
can usually ignore this section, or remove it. However, fairly sized PRs (such as a class rewrite)
should go into detail about the changes here.
-->

Getting the town from the outlaw's location returns the town or null if not present, using a different TownyAPI method.
____
#### Relevant FlagWar Issue tickets:
<!--
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
If you add issues manually on the sidebar, you can safely delete this heading. If using keywords,
please use an unordered list should you need to reference more than one issue.
--->

- Closes #78
____
- [ ] I have tested this pull request for defects on a server.
<!-- Replace `[ ]` with `[x]` if completed. --->

---
By making this pull request, I represent that I have read and agree to release my own changes that I
have submitted under the terms of the accompanying license (Apache-2.0). I guarantee that these
changes are mine and are not encumbered by any other license or restriction to the best of my
knowledge.

<!-- For co-authored commits, all co-authors will need to reply to this PR within a 48 Hrs.
If no replies have been left within a reasonable period, we may attempt to contact them by their
email tied to their commits, OR reject the PR at our discretion.

For Co-authoring docs, see:
https://docs.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors
--->
