### PR TITLE
Create Translation_fr_FR.properties

### DIFF
--- a/src/main/resources/Translation_fr_FR.properties
+++ b/src/main/resources/Translation_fr_FR.properties
@@ -1,0 +1,67 @@
+
+## Placeholders
+locale=Français (France)
+locale-version=1.1
+message-prefix=&6[FlagWar] %s
+
+# Log-only Messages (Does not use message-prefix)
+shutdown.cancel-all=Tentative d'annulation de toutes les attaques. (S'il en existe...)
+startup.check-towny.good-to-go=Aucun problème de compatibilité avec Towny. Prêt à démarrer!
+startup.check-towny.isError=Towny est verrouillé! Désactivation de FlagWar!
+startup.check-towny.not-running=Towny n'est pas en fonctionnement, ou n'est simplement pas présent. Désactivation de FlagWar!
+startup.check-towny.notify=Vérification auprès de Towny...
+startup.check-towny.outdated=La version de Towny est trop ancienne! Pour utiliser FlagWar, tu dois avoir Towny v%s minimum.
+startup.events.register=Enregistrement des Events...
+startup.events.registered=Events enregistrés.
+startup.listeners.initialize=Enregistrement des Listeners...
+startup.listeners.initialized=Listeners enregistrés.
+startup.load-materials.invalid-base-block=Bloc de base du Drapeau de guerre incorrectement défini. Défini en barrière en chêne (OAK_FENCE) par défaut.
+startup.load-materials.invalid-beacon-wireframe=Faisceau de balise incorrectement défini. Défini en Pierre lumineuse (GLOWSTONE) par défaut.
+startup.load-materials.invalid-light-block= Bloc lumineux incorrectement défini. Défini en torche (TORCH) par défaut.
+startup.load-materials.notify=Chargement de la liste de matériaux...
+startup.marquee-art=%n\
+  %n            ▄████  █    ██     ▄▀        ▄ ▄   ██   █▄▄▄▄\
+  %n            █▀   ▀ █    █ █  ▄▀         █   █  █ █  █  ▄▀\
+  %n            █▀▀    █    █▄▄█ █ ▀▄      █ ▄   █ █▄▄█ █▀▀▌\
+  %n            █      ███▄ █  █ █   █     █  █  █ █  █ █  █\
+  %n             █         ▀   █  ███       █ █ █     █   █\
+  %n              ▀           █              ▀ ▀     █   ▀\
+  %n                         ▀                      ▀
+log.warflag-updated=Flag en %s changé en %s.%n
+
+## Global Broadcasts
+broadcast.area.defended=&b%s défendue (%s)!
+broadcast.area.pillaged=&c%s pillée %s par %s.
+broadcast.area.rebuilding=&c%s payé %s à %s pour reconstruire.
+broadcast.area.under_attack=&b%s (%s) est attaqué par %s!
+broadcast.area.won=&b%s (%s) remportée (%s)!
+
+## Resident-specific Messages
+area.defended.attacker.greater-forces=&cVotre attaque échouée vous a couté %s.
+area.defended.attacker=&cVous avez été forcé de payer %s %s pour votre attaque échouée.
+area.defended.defender=&c%sVous a payé %s pour l'attaque échouée.
+warflag-purchased=&cVous avez payé %s de taxes pour attaquer.
+
+## Town-Specific Messages
+area.won.defender-keeps-claims=Capture désactivée. La ville défenseuse garde ses terrains.
+
+## Event Cancellation and Exception messages
+error.area-not-in-nation=&cCette zone n'appartient pas à une nation.
+error.border-attack-only=&cSeules les attaques sur les bordures de ville sont autorisées.
+error.cannot-toggle-peaceful=&cLa paix n'est pas une option! Bas-toi comme un roi!
+error.cell-already-under-attack=&cCette zone est déjà attaquée par %s.
+error.flag.insufficient-funds=&cVous avez besoin de %s pour placer un drapeau de guerre.
+error.flag.max-flags-placed=&cVous ne pouvez attaquer plus de %d zones à la fois.
+error.flag.need-above-ground=&cUn drapeau doit être posé au sol.
+error.insufficient-future-funds=&cVous avez besoin de %s durant l'événement pour payer %d %s(s).
+error.nation-under-attack=&cVous ne pouvez faire cela lorsqu'une ville de votre nation est attaquée!
+error.need-at-least-1-claim=&cVous ne pouvez pas attaquer une ville n'ayant aucun terrain.
+error.not-enough-online-players=&cAu moins %d personnes doivent être présente dans %s pour attaquer.
+error.player-not-in-nation=&bVous n'appartenez pas à une nation.
+error.player-town-under-attack=&cVous ne pouvez pas faire cela lorsque vous êtes attaqué!
+error.player-was-recently-attacked=&cVous ne pouvez pas faire cela! Vous avez été attaqué récemment et êtes en alerte maximale!
+error.target-is-peaceful=&c%s est pacifique.
+error.warzone.cannot-edit=&cImpossible de %s %s dans une Zone de Guerre.
+error.warzone.cannot-use-item=&cImpossible d'utiliser cet objet dans une Zone de Guerre.
+error.warzone.cannot-use-switch=&cImpossible d'utiliser les ''switch'' dans une zone de guerre.
+message.outlaw.bypass-outlaw-teleport-event=&cVous êtes entré dans %s comme un membre des envahisseurs.


### PR DESCRIPTION
Add French Translation for FlagWar

#### Brief Description:
**I've written fr_FR locale for Flagwar.
I've used en_US as base and changed everything after "=".
I'm not a dev, so **i haven't tested** my locale, but I've carefully make every trad to ensure avoiding incompatibility.

Translator Choices:
- I haven't translated some specific terms like 'Events' and 'Listeners' because it's programmatic languages which users don't see and admin need to know (at least by name).
- I haven't translated 'switches', because it's not translated inside towny's locale. So I've used ' ' switch ' ' to replace it like inside towny's locale.
- I've added English (MATERIAL) for invalid-materials lines. Cause they're formatted like that inside config.
- I've used respectful pronouns (Vous) as 'YOU', to keep clean expression, but i can use (tu) which is more familiar 
- FlagWar is still FlagWar and Towny is still Towny**

____
- [ ] I have tested this pull request for defects on a server.

---
By making this pull request, I represent that I have read and agree to release my own changes that I
have submitted under the terms of the accompanying license (Apache-2.0). I guarantee that these
changes are mine and are not encumbered by any other license or restriction to the best of my
knowledge.
