### PR TITLE
Initial Use of the Java.Time API

### DIFF
--- a/src/main/java/io/github/townyadvanced/flagwar/FlagWar.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/FlagWar.java
@@ -50,6 +50,7 @@ import io.github.townyadvanced.flagwar.objects.CellUnderAttack;
 
 import java.io.IOException;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -79,7 +80,7 @@ public class FlagWar extends JavaPlugin {
     /** Holds a map of {@link Player}s and a list of {@link CellUnderAttack} flagged by them. */
     private static final Map<String, List<CellUnderAttack>> PLAYER_ATTACK_HASH_MAP = new HashMap<>();
     /** Holds a map of {@link Town}s, and when they were last flagged. */
-    private static final Map<Town, Long> TOWN_LAST_FLAGGED_HASH_MAP = new HashMap<>();
+    private static final Map<Town, Instant> TOWN_LAST_FLAGGED_HASH_MAP = new HashMap<>();
     /** FlagWar Copyright String. */
     private static final String FW_COPYRIGHT = "Copyright \u00a9 2021 TownyAdvanced";
     /** Version object for storing the minimum required version of Towny for compatibility. */
@@ -724,11 +725,16 @@ public class FlagWar extends JavaPlugin {
         return new WorldCoord(cell.getWorldName(), cell.getX(), cell.getZ());
     }
 
-    static long lastFlagged(final Town town) {
+    /**
+     * Returns an {@link Instant} for which a {@link Town} was flagged, if it is within appropriate HashMap.
+     * @param town Target Town
+     * @return An Instant
+     */
+    static Instant lastFlagged(final Town town) {
         if (TOWN_LAST_FLAGGED_HASH_MAP.containsKey(town)) {
             return TOWN_LAST_FLAGGED_HASH_MAP.get(town);
         }
-        return 0;
+        return Instant.EPOCH;
     }
 
     /**
@@ -737,9 +743,9 @@ public class FlagWar extends JavaPlugin {
      */
     public static void townFlagged(final Town town) {
         if (TOWN_LAST_FLAGGED_HASH_MAP.containsKey(town)) {
-            TOWN_LAST_FLAGGED_HASH_MAP.replace(town, System.currentTimeMillis());
+            TOWN_LAST_FLAGGED_HASH_MAP.replace(town, Instant.now());
         } else {
-            TOWN_LAST_FLAGGED_HASH_MAP.put(town, System.currentTimeMillis());
+            TOWN_LAST_FLAGGED_HASH_MAP.put(town, Instant.now());
         }
     }
 }

--- a/src/main/java/io/github/townyadvanced/flagwar/FlagWarAPI.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/FlagWarAPI.java
@@ -145,11 +145,19 @@ public final class FlagWarAPI {
     }
 
     /**
-     * Gets the time between when a flag and it's beacon shifts colors.
-     * @return a {@link Long} value of the total time between a flag's color shift.
+     * Gets the time in ticks between when a Flag shifts phases.
+     * <p>
+     *     This is achieved by dividing the time in milliseconds by 50 to get tick count.
+     *     Calculations are done without rounding; so while 450 ms would be 9 ticks, so too would 499 ms.
+     * </p>
+     * @return Expected ticks of a war flag timer phase.
+     * @deprecated Lack of documentation may have lead to confusion on which unit was used for measuring the time.
+     * Use {@link FlagWarConfig#getFlagPhasesDuration()} if possible. It can be converted as needed.
      */
+    @Deprecated(since = "0.5.2", forRemoval = true)
     public static long getMaterialShiftTime() {
-        return FlagWarConfig.getTimeBetweenFlagColorChange();
+        final int millisPerTick = 50;
+        return FlagWarConfig.getFlagPhasesDuration().toMillis() / millisPerTick;
     }
 
 }

--- a/src/main/java/io/github/townyadvanced/flagwar/FlagWarAPI.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/FlagWarAPI.java
@@ -22,6 +22,8 @@ import com.palmergames.bukkit.towny.object.Town;
 import io.github.townyadvanced.flagwar.config.FlagWarConfig;
 import io.github.townyadvanced.flagwar.objects.Cell;
 import io.github.townyadvanced.flagwar.objects.CellUnderAttack;
+
+import java.time.Instant;
 import java.util.List;
 import org.bukkit.entity.Player;
 
@@ -124,8 +126,21 @@ public final class FlagWarAPI {
      * Get a timestamp for when a {@link Town} was last flagged.
      * @param town The town to check.
      * @return the previous timestamp for when the town was flagged, in milliseconds.
+     *         Note that it is possible to return the value of the Epoch, zero,
+     *         when the town is not in the last-flagged hash map privately defined by {@link FlagWar}.
+     * @deprecated Superseded by the {@link #getFlaggedInstant(Town)} method.
      */
+    @Deprecated (since = "0.5.2", forRemoval = true)
     public static long getFlaggedTimestamp(final Town town) {
+        return getFlaggedInstant(town).toEpochMilli();
+    }
+
+    /**
+     * Get the Instant for when a {@link Town} was last flagged.
+     * @param town Target Town.
+     * @return Instant of last flag.
+     */
+    public static Instant getFlaggedInstant(final Town town) {
         return FlagWar.lastFlagged(town);
     }
 

--- a/src/main/java/io/github/townyadvanced/flagwar/config/FlagWarConfig.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/config/FlagWarConfig.java
@@ -25,6 +25,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NonNls;
 
+import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -403,11 +404,23 @@ public final class FlagWarConfig {
         return PLUGIN.getConfig().getInt("beacon.height_above_flag.min");
     }
 
-    /** @return the value of 'rules.prevented_interaction_cooldown' in milliseconds, or the default value (10 min.) */
+    /** Get the value of 'rules.prevented_interaction_cooldown' in milliseconds, or the default value. (10 min)
+     * @return the value, or 600000(ms)
+     * @deprecated Method superceded by {@link #getFlaggedInteractCooldown()}
+     */
+    @Deprecated (since = "0.5.2", forRemoval = true)
     public static long getTimeToWaitAfterFlagged() {
         String timeString = PLUGIN.getConfig().getString("rules.prevented_interaction_cooldown");
         final long defValue = 600000;
         return timeString != null ? TimeTools.getMillis(timeString) : defValue;
+    }
+
+    /**
+     * Calculates the {@link Duration} from the value (in ms) from <code>rules.prevented_interaction_cooldown</code>.
+     * @return The calculated Duration.
+     */
+    public static Duration getFlaggedInteractCooldown() {
+        return Duration.ofMillis(PLUGIN.getConfig().getLong("rules.prevented_interaction_cooldown"));
     }
 
     /** @return the value of 'rules.prevent_interaction_while_flagged.town'. */

--- a/src/main/java/io/github/townyadvanced/flagwar/listeners/FlagWarCustomListener.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/listeners/FlagWarCustomListener.java
@@ -51,6 +51,8 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.jetbrains.annotations.NotNull;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.logging.Logger;
 
 /**
@@ -491,14 +493,14 @@ public class FlagWarCustomListener implements Listener {
 
     /**
      * Determines if the given {@link Town} is still in the cooldown period defined by
-     * {@link FlagWarConfig#getTimeToWaitAfterFlagged()}.
+     * {@link FlagWarConfig#getFlaggedInteractCooldown()}.
      *
-     * @param town the Town to inspect for cooldown.
+     * @param town The Town to inspect for cooldown.
      * @return TRUE if the cooldown is still active.
      */
     private boolean isAfterFlaggedCooldownActive(final Town town) {
-        long timeToWait = FlagWarConfig.getTimeToWaitAfterFlagged();
-        return System.currentTimeMillis() - FlagWarAPI.getFlaggedTimestamp(town) < timeToWait;
+        Duration timeToWait = FlagWarConfig.getFlaggedInteractCooldown();
+        return Instant.now().isAfter(FlagWarAPI.getFlaggedInstant(town).plus(timeToWait));
     }
 
     /**


### PR DESCRIPTION
#### Brief Description:
<!-- Describe your Pull Request's purpose here please. --->

Replaces most usages of long for storing timestamps and durations with the `java.time` API. Most values are now either stored as `java.time.Instant` or `java.time.Duration`.

____
#### Changes:
<!-- 
Please state your changes in human-readable format if the Description isn't enough detail. Small PRs
can usually ignore this section, or remove it. However, fairly sized PRs (such as a class rewrite)
should go into detail about the changes here.
-->

- Flag Timer Phases now stored as `java.time.Duration` and converted to ticks only when ticks are needed.
- Timestamps for when a town was last flagged are now stored as `java.time.Instant`, with null/0 now mapped to `Instant.EPOCH`.
- Ticks calculated from millisecond precision use timeMillis / 50. The value is floored to the whole tick (int math).
- Deprecates some methods while attempting to preserve their functionality until removed.

____
#### Relevant FlagWar Issue tickets:
<!--
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
If you add issues manually on the sidebar, you can safely delete this heading. If using keywords,
please use an unordered list should you need to reference more than one issue.
--->


____
- [ ] I have tested this pull request for defects on a server.
<!-- Replace `[ ]` with `[x]` if completed. --->

---
By making this pull request, I represent that I have read and agree to release my own changes that I
have submitted under the terms of the accompanying license (Apache-2.0). I guarantee that these
changes are mine and are not encumbered by any other license or restriction to the best of my
knowledge.

<!-- For co-authored commits, all co-authors will need to reply to this PR within a 48 Hrs.
If no replies have been left within a reasonable period, we may attempt to contact them by their
email tied to their commits, OR reject the PR at our discretion.

For Co-authoring docs, see:
https://docs.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors
--->
