### PR TITLE
Remove deprecated calls to TownyMessaging.sendResidentMessage.

### DIFF
--- a/src/main/java/io/github/townyadvanced/flagwar/listeners/FlagWarCustomListener.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/listeners/FlagWarCustomListener.java
@@ -28,7 +28,6 @@ import com.palmergames.bukkit.towny.event.town.TownLeaveEvent;
 import com.palmergames.bukkit.towny.event.town.TownPreSetHomeBlockEvent;
 import com.palmergames.bukkit.towny.event.town.TownPreUnclaimCmdEvent;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
-import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
@@ -578,29 +577,20 @@ public class FlagWarCustomListener implements Listener {
     }
 
     private void messageResident(final Resident resident, final String message) {
-        try {
-            TownyMessaging.sendResidentMessage(resident, message);
-        } catch (TownyException e) {
-            logger.warning("Unable to send resident a message.");
-            logger.warning(e.getMessage());
+        if (resident.isOnline()) {
+            resident.getPlayer().sendMessage(message);
         }
     }
 
     private void msgAttackDefended(final Resident atkRes, final Resident defRes, final String formattedMoney) {
         String message;
-        try {
-            message = Translate.fromPrefixed("area.defended.attacker", defRes.getFormattedName(), formattedMoney);
-            TownyMessaging.sendResidentMessage(atkRes, message);
-        } catch (TownyException e) {
-            logger.warning("Unable to message an attacker about a defended attack!");
-            logger.warning(e.getMessage());
+        message = Translate.fromPrefixed("area.defended.attacker", defRes.getFormattedName(), formattedMoney);
+        if (atkRes.isOnline()) {
+            atkRes.getPlayer().sendMessage(message);
         }
-        try {
-            message = Translate.fromPrefixed("area.defended.defender", atkRes.getFormattedName(), formattedMoney);
-            TownyMessaging.sendResidentMessage(defRes, message);
-        } catch (TownyException e) {
-            logger.warning("Unable to message a defender about a defended attack!");
-            logger.warning(e.getMessage());
+        message = Translate.fromPrefixed("area.defended.defender", atkRes.getFormattedName(), formattedMoney);
+        if (defRes.isOnline()) {
+            defRes.getPlayer().sendMessage(message);
         }
     }
 }


### PR DESCRIPTION
#### Brief Description:
<!-- Describe your Pull Request's purpose here please. --->
These methods were already being prefixed by FlagWar's prefix, and by
sending it to TownyMessaging was adding another Towny prefix.

FlagWar is already handling Translations to other languages, so I don't
think we have to worry about Translatable objects in FlagWar.

____
#### Changes:
<!-- 
Please state your changes in human-readable format if the Description isn't enough detail. Small PRs
can usually ignore this section, or remove it. However, fairly sized PRs (such as a class rewrite)
should go into detail about the changes here.
-->

____
#### Relevant FlagWar Issue tickets:
<!--
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
If you add issues manually on the sidebar, you can safely delete this heading. If using keywords,
please use an unordered list should you need to reference more than one issue.
--->


____
- [ ] I have tested this pull request for defects on a server.
<!-- Replace `[ ]` with `[x]` if completed. --->

---
By making this pull request, I represent that I have read and agree to release my own changes that I
have submitted under the terms of the accompanying license (Apache-2.0). I guarantee that these
changes are mine and are not encumbered by any other license or restriction to the best of my
knowledge.

<!-- For co-authored commits, all co-authors will need to reply to this PR within a 48 Hrs.
If no replies have been left within a reasonable period, we may attempt to contact them by their
email tied to their commits, OR reject the PR at our discretion.

For Co-authoring docs, see:
https://docs.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors
--->
