### PR TITLE
Bump Snapshot and Baseline Targets

### DIFF
--- a/.github/workflows/compile-on-push.yml
+++ b/.github/workflows/compile-on-push.yml
@@ -5,7 +5,7 @@ jobs:
         runs-on: ubuntu-22.04
         strategy:
             matrix:
-                java: ['16', '17', '19']
+                java: ['17', '19']
         name: Java ${{ matrix.java }}
         steps:
             - uses: actions/checkout@v3

--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,11 @@
     <groupId>io.github.townyadvanced.flagwar</groupId>
     <artifactId>FlagWar</artifactId>
     <packaging>jar</packaging>
-    <version>0.5.3</version>
+    <version>0.5.4-SNAPSHOT</version>
     <description>An OG war system for TownyAdvanced. Celebrating a decade of Flag-based Towny Warfare.</description>
 
     <properties>
-        <java.version>16</java.version>
+        <java.version>17</java.version>
         <project.bukkitAPIVersion>1.17</project.bukkitAPIVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>towny</artifactId>
-            <version>0.98.3.14</version>
+            <version>0.98.4.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         </license>
         <license>
             <name>Creative Commons Attribution 4.0 International (CC BY 4.0)</name>
-            <comments>Governs written documentation for FlagWar.</comments>
+            <comments>Governs written documentation and artistic assetsint for FlagWar.</comments>
             <url>https://creativecommons.org/licenses/by/4.0/legalcode</url>
         </license>
     </licenses>

--- a/src/main/java/io/github/townyadvanced/flagwar/FlagWar.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/FlagWar.java
@@ -87,7 +87,7 @@ public class FlagWar extends JavaPlugin {
     /** Holds a map of {@link Town}s, and when they were last flagged. */
     private static final Map<Town, Instant> TOWN_LAST_FLAGGED_HASH_MAP = new HashMap<>();
     /** FlagWar Copyright String. */
-    private static final String FW_COPYRIGHT = "Copyright \u00a9 2021 TownyAdvanced";
+    private static final String FW_COPYRIGHT = "Copyright \u00a9 2021–2023 TownyAdvanced";
     /** Version for storing the minimum required version of Towny, for compatibility. */
     private static final Version MIN_TOWNY_VER = Version.fromString("0.98.3.14");
     /** Version for storing the latest supported version of Towny, for validation. */
@@ -174,7 +174,7 @@ public class FlagWar extends JavaPlugin {
             ? Objects.requireNonNull(plugin.getConfig().getString("translation")) : "en_US");
     }
 
-    /** Register FlagWar with bStats. Viewable from: https://bstats.org/plugin/bukkit/FlagWar/ */
+    /** Register FlagWar with bStats. Viewable from: <a href="https://bstats.org/plugin/bukkit/FlagWar/">...</a> */
     @SuppressFBWarnings("DLS_DEAD_LOCAL_STORE")
     @SuppressWarnings({"unused", "java:S1854", "java:S1481"})
     private void bStatsKickstart() {

--- a/src/main/java/io/github/townyadvanced/flagwar/FlagWar.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/FlagWar.java
@@ -89,9 +89,9 @@ public class FlagWar extends JavaPlugin {
     /** FlagWar Copyright String. */
     private static final String FW_COPYRIGHT = "Copyright \u00a9 2021 TownyAdvanced";
     /** Version for storing the minimum required version of Towny, for compatibility. */
-    private static final Version MIN_TOWNY_VER = Version.fromString("0.98.1.0");
+    private static final Version MIN_TOWNY_VER = Version.fromString("0.98.3.14");
     /** Version for storing the latest supported version of Towny, for validation. */
-    private static final Version VALID_TOWNY_VER = Version.fromString("0.98.1.0");
+    private static final Version VALID_TOWNY_VER = Version.fromString("0.98.4.0");
     /** Value of minimum configuration file version. Used for determining if file should be regenerated. */
     private static final double MIN_CONFIG_VER = 1.6;
     /** BStats Metrics ID. */

--- a/src/main/java/io/github/townyadvanced/flagwar/listeners/FlagWarBlockListener.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/listeners/FlagWarBlockListener.java
@@ -126,7 +126,7 @@ public class FlagWarBlockListener implements Listener {
      * Iteratively runs over {@link FlagWar#checkBlock(Player, Block, org.bukkit.event.Cancellable)} using the event's
      * {@link Player}, {@link Block} ({@link BlockPistonRetractEvent#getBlocks()}), and the
      * {@link BlockPistonRetractEvent} itself.
-     *
+     * <br/>
      * Fails fast if {@link BlockPistonRetractEvent#isSticky()} is false.
      *
      * @param blockPistonRetractEvent the {@link BlockPistonRetractEvent}.
@@ -158,7 +158,7 @@ public class FlagWarBlockListener implements Listener {
                 event.setCancelled(false);
             }
         } catch (TownyException townyException) {
-            event.setMessage(townyException.getMessage());
+            event.setCancelMessage(townyException.getMessage());
         }
     }
 }

--- a/src/main/java/io/github/townyadvanced/flagwar/listeners/WarzoneListener.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/listeners/WarzoneListener.java
@@ -73,7 +73,7 @@ public class WarzoneListener implements Listener {
 
         if (!FlagWarConfig.isEditableMaterialInWarZone(mat)) {
             townyDestroyEvent.setCancelled(true);
-            townyDestroyEvent.setMessage(msgCannotEdit("destroy", mat));
+            townyDestroyEvent.setCancelMessage(msgCannotEdit("destroy", mat));
             return;
         }
         townyDestroyEvent.setCancelled(false);
@@ -97,7 +97,7 @@ public class WarzoneListener implements Listener {
 
         if (!FlagWarConfig.isEditableMaterialInWarZone(mat)) {
             townyBuildEvent.setCancelled(true);
-            townyBuildEvent.setMessage(msgCannotEdit("build", mat));
+            townyBuildEvent.setCancelMessage(msgCannotEdit("build", mat));
             return;
         }
         townyBuildEvent.setCancelled(false);
@@ -120,7 +120,7 @@ public class WarzoneListener implements Listener {
 
         if (!FlagWarConfig.isAllowingItemUseInWarZone()) {
             townyItemuseEvent.setCancelled(true);
-            townyItemuseEvent.setMessage(Translate.from("error.warzone.cannot-use-item"));
+            townyItemuseEvent.setCancelMessage(Translate.from("error.warzone.cannot-use-item"));
             return;
         }
         townyItemuseEvent.setCancelled(false);
@@ -143,7 +143,7 @@ public class WarzoneListener implements Listener {
 
         if (!FlagWarConfig.isAllowingSwitchInWarZone()) {
             townySwitchEvent.setCancelled(true);
-            townySwitchEvent.setMessage(Translate.from("error.warzone.cannot-use-switch"));
+            townySwitchEvent.setCancelMessage(Translate.from("error.warzone.cannot-use-switch"));
             return;
         }
         townySwitchEvent.setCancelled(false);
@@ -197,9 +197,9 @@ public class WarzoneListener implements Listener {
         || !FlagWarConfig.isAllowingExplosionsToBreakBlocksInWarZone()) {
             return;
         }
-        List<Block> toAllow = new ArrayList<Block>();
+        List<Block> toAllow = new ArrayList<>();
         for (Block block : event.getVanillaBlockList()) {
-            // Wilderness or not located inside of a Cell which is under attack, skip it.
+            // Wilderness or not located inside a Cell which is under attack, skip it.
             if (TownyAPI.getInstance().isWilderness(block)
             || !Cell.parse(block.getLocation()).isUnderAttack()) {
                 continue;
@@ -208,7 +208,9 @@ public class WarzoneListener implements Listener {
             toAllow.add(block);
         }
         // Add all TownyFilteredBlocks to our list, since our list will be used.
-        toAllow.addAll(event.getTownyFilteredBlockList());
+        if (event.getTownyFilteredBlockList() != null) {
+            toAllow.addAll(event.getTownyFilteredBlockList());
+        }
 
         // Return the list of allowed blocks for this block explosion event.
         event.setBlockList(toAllow);


### PR DESCRIPTION
This PR updates FlagWar to 0.5.4-SNAPSHOT.

Minimum requirements for operation change:
- Java 17+ required (JDK 16 support removed)
- Towny 0.98.3.11 is now the minimum compatible version of Towny.  (Targets 0.98.4.0 _Stable_)
  - Required to drop deprecated call.
-  Errata changes:
   - In addition to the documentation, CC-BY-4.0 covers any artistic assets hosted (e.g. a future FlagWar logo, documentation visual aides, etc.)
   - Updated console copyright tagline to '2021-2023'.