### PR TITLE
Transfer of Maintainership

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
 
-github: [LlmDl, TheFlagCourier]
+github: [LlmDl]

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Documentation could also use a fair bit of work. Help in this department would b
 We document both in plain-text (LICENSE, NOTICE) and in GitHub-Flavored Markdown (everywhere else).
 
 If you are interested in writing for the [FlagWar Wiki][wiki], feel free to ask on the [Towny Discord][discord]
-(ping FlagCourier), or chime in on the [Towny Discussion Board][discuss-towny] to be given write access. 
+(please use the `#flagwar` channel), or chime in on the [Towny Discussion Board][discuss-towny] to be given write access. 
 
 ### Localizing FlagWar
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,10 @@
             <name>FlagCourier</name>
             <email>flagcourier@pm.me</email>
             <organization>Towny Advanced</organization>
-            <roles><role>FlagWar Maintainer</role></roles>
+            <roles>
+                <role>Contributor</role>
+                <role>Former FlagWar Maintainer (2021&ndash;2023)</role>
+            </roles>
             <timezone>-6</timezone>
             <url>https://github.com/FlagCourier</url>
         </developer>


### PR DESCRIPTION
#### Brief Description:
<!-- Describe your Pull Request's purpose here please. --->

I have not displayed an adequate level of involvement with its maintenance over the last year. If anything, the last major commit would have been in August, just before releasing 0.5.3. The majority of contributions since have come from @LlmDl and automated dependency updates. So, given that I cannot seem to dedicate enough time, I will be stepping down as its maintainer. Please see the Discord for more information, and on-going efforts.

This PR tracks clerical changes necessary to transfer to a new maintainer. Things will be added to it as I come across them.

____
#### Changes:
<!-- 
Please state your changes in human-readable format if the Description isn't enough detail. Small PRs
can usually ignore this section, or remove it. However, fairly sized PRs (such as a class rewrite)
should go into detail about the changes here.
-->

- Remove link to GitHub Sponsors (Personal Only)
- Update roles in POM
- Remove instruction to Ping on Readme - direct to '#flagwar' channel instead.
