### PR TITLE
Add the ability to protect an area surrounding the flag from building.

### DIFF
--- a/src/main/java/io/github/townyadvanced/flagwar/config/FlagWarConfig.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/config/FlagWarConfig.java
@@ -564,6 +564,20 @@ public final class FlagWarConfig {
         return editableMaterialsInWarZone.contains(material);
     }
 
+    /**
+     * @return true when the flag is protected from the editable materials.
+     */
+    public static boolean isFlagAreaProtectedFromEditableMaterials() {
+        return PLUGIN.getConfig().getInt("warzone.protected_area_surrounding_flag") > 0;
+    }
+
+    /**
+     * @return the size of the protection area surrounding the flag.
+     */
+    public static int getFlagAreaProtectedSize() {
+        return PLUGIN.getConfig().getInt("warzone.protected_area_surrounding_flag");
+    }
+
     /** @return whether nations are allowed to toggle neutral.*/
     public static boolean isDeclaringNeutralAllowed() {
         return PLUGIN.getConfig().getBoolean("rules.nations_can_toggle_neutral");

--- a/src/main/java/io/github/townyadvanced/flagwar/listeners/WarzoneListener.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/listeners/WarzoneListener.java
@@ -33,10 +33,12 @@ import io.github.townyadvanced.flagwar.FlagWarAPI;
 import io.github.townyadvanced.flagwar.config.FlagWarConfig;
 import io.github.townyadvanced.flagwar.i18n.Translate;
 import io.github.townyadvanced.flagwar.objects.Cell;
+import io.github.townyadvanced.flagwar.objects.CellUnderAttack;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
@@ -92,6 +94,10 @@ public class WarzoneListener implements Listener {
         TownBlockStatus status = towny.getCache(player).getStatus();
 
         if (isFastFailing(status, townyBuildEvent)) {
+            return;
+        }
+
+        if (isTooCloseToTheFlag(status, townyBuildEvent)) {
             return;
         }
 
@@ -249,6 +255,31 @@ public class WarzoneListener implements Listener {
             || !FlagWarConfig.isAllowingAttacks()
             || townyActionEvent.isInWilderness()
             || !FlagWarAPI.isUnderAttack(Cell.parse(townyActionEvent.getLocation()));
+    }
+
+    /**
+     * Tell the calling method to fail if the block is too close to the flag.
+     *
+     * @param townBlockStatus The {@link TownBlockStatus} passed to, or established by, the original method.
+     * @param townyActionEvent  The {@link TownyActionEvent} member being checked by the originating method.
+     * @return True if any of the conditions are met.
+     */
+    private boolean isTooCloseToTheFlag(final TownBlockStatus townBlockStatus,
+            final TownyActionEvent townyActionEvent) {
+        if (!FlagWarConfig.isFlagAreaProtectedFromEditableMaterials()) {
+            return false;
+        }
+
+        Location blockLoc = townyActionEvent.getLocation();
+        CellUnderAttack cellData = FlagWarAPI.getAttackData(Cell.parse(blockLoc));
+        Location flagLoc = cellData.getFlagBaseBlock().getLocation();
+        // We don't care if the flag is above the block being placed.
+        if (blockLoc.getY() < flagLoc.getY()) {
+            return false;
+        }
+        // Set the y value to the flag y value so we compare only the horizontal distance.
+        blockLoc.setY(flagLoc.getY());
+        return blockLoc.distance(flagLoc) <= FlagWarConfig.getFlagAreaProtectedSize();
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -16,7 +16,7 @@
 ################################################################################
 
 # Note: Do not modify config_version, unless you want to regenerate your config
-config_version: 1.6
+config_version: 1.7
 
 # Please see https://github.com/TownyAdvanced/FlagWar/tree/main/src/main/resources/
 # for available translations. Custom translations are only supported if they are merged.
@@ -158,6 +158,8 @@ warzone:
     explosions: true
     explosions_break_blocks: true
 
+    # The space around the flag where editable materials cannot be used.
+    protected_area_surrounding_flag: 0
 extra:
     # If enabled, show additional debug messages as warnings. Recommended keeping these disabled unless requested.
     debug: false


### PR DESCRIPTION

#### Brief Description:
<!-- Describe your Pull Request's purpose here please. --->
Makes it so that the editable materials cannot be used too close to the flag.


____
#### Changes:
<!-- 
Please state your changes in human-readable format if the Description isn't enough detail. Small PRs
can usually ignore this section, or remove it. However, fairly sized PRs (such as a class rewrite)
should go into detail about the changes here.
-->
Adds 
```
    # The space around the flag where editable materials cannot be used.
    protected_area_surrounding_flag: 0
```
To the warzone section of the config.
____
#### Relevant FlagWar Issue tickets:
<!--
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
If you add issues manually on the sidebar, you can safely delete this heading. If using keywords,
please use an unordered list should you need to reference more than one issue.
--->

Closes #398.
____
- [ ] I have tested this pull request for defects on a server.
<!-- Replace `[ ]` with `[x]` if completed. --->

---
By making this pull request, I represent that I have read and agree to release my own changes that I
have submitted under the terms of the accompanying license (Apache-2.0). I guarantee that these
changes are mine and are not encumbered by any other license or restriction to the best of my
knowledge.

<!-- For co-authored commits, all co-authors will need to reply to this PR within a 48 Hrs.
If no replies have been left within a reasonable period, we may attempt to contact them by their
email tied to their commits, OR reject the PR at our discretion.

For Co-authoring docs, see:
https://docs.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors
--->
