### PR TITLE
Fix CellWonEvent being unable to be acted upon.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.townyadvanced.flagwar</groupId>
     <artifactId>FlagWar</artifactId>
     <packaging>jar</packaging>
-    <version>0.7.0</version>
+    <version>0.7.1</version>
     <description>An OG war system for TownyAdvanced. Celebrating a decade of Flag-based Towny Warfare.</description>
 
     <properties>

--- a/src/main/java/io/github/townyadvanced/flagwar/listeners/FlagWarCustomListener.java
+++ b/src/main/java/io/github/townyadvanced/flagwar/listeners/FlagWarCustomListener.java
@@ -135,7 +135,7 @@ public class FlagWarCustomListener implements Listener {
      *
      * @param cellWonEvent The event declaring the cell attack successfully completed, and triggers the processing.
      */
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onCellWonEvent(final CellWonEvent cellWonEvent) {
         if (cellWonEvent.isCancelled()) {
             return;


### PR DESCRIPTION


#### Brief Description:
<!-- Describe your Pull Request's purpose here please. --->

When run at LOWEST no plugin could act on the CellWonEvent without cancelling the event and then re-firing it (and potentially not getting it in before FlagWar operates off of it anyways.)


____
#### Changes:
<!-- 
Please state your changes in human-readable format if the Description isn't enough detail. Small PRs
can usually ignore this section, or remove it. However, fairly sized PRs (such as a class rewrite)
should go into detail about the changes here.
-->
This change makes the FW plugin act upon its own CellWonEvent on MONITOR priority, after other plugins have had their chance at listening/cancelling it on all of the other, lower priorities.


____
#### Relevant FlagWar Issue tickets:
<!--
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
If you add issues manually on the sidebar, you can safely delete this heading. If using keywords,
please use an unordered list should you need to reference more than one issue.
--->

Closes #405.
____
- [ ] I have tested this pull request for defects on a server.
<!-- Replace `[ ]` with `[x]` if completed. --->

---
By making this pull request, I represent that I have read and agree to release my own changes that I
have submitted under the terms of the accompanying license (Apache-2.0). I guarantee that these
changes are mine and are not encumbered by any other license or restriction to the best of my
knowledge.

<!-- For co-authored commits, all co-authors will need to reply to this PR within a 48 Hrs.
If no replies have been left within a reasonable period, we may attempt to contact them by their
email tied to their commits, OR reject the PR at our discretion.

For Co-authoring docs, see:
https://docs.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors
--->
