### PR TITLE
Fix jitpack.yml java version not allowing build on the repo.

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -4,7 +4,7 @@
 before_install:
     - source "$HOME/.sdkman/bin/sdkman-init.sh"
     - sdk update
-    - sdk install java 17.0.4.1-tem
-    - sdk use java 17.0.4.1-tem
+    - sdk install java 21-tem
+    - sdk use java 21-tem
     - sdk install maven 3.8.6
     - sdk use maven 3.8.6


### PR DESCRIPTION
#### Brief Description:
<!-- Describe your Pull Request's purpose here please. --->

Jitpack.yml still had java 17, causing 0.7.0 not to build: https://jitpack.io/com/github/TownyAdvanced/FlagWar/0.7.0/build.log
____
#### Changes:
<!-- 
Please state your changes in human-readable format if the Description isn't enough detail. Small PRs
can usually ignore this section, or remove it. However, fairly sized PRs (such as a class rewrite)
should go into detail about the changes here.
-->
Updated jitpack.yml to use Java 21.
____
#### Relevant FlagWar Issue tickets:
<!--
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
If you add issues manually on the sidebar, you can safely delete this heading. If using keywords,
please use an unordered list should you need to reference more than one issue.
--->


____
- [x] I have tested this pull request for defects: https://jitpack.io/com/github/TownyAdvanced/FlagWar/fix~jitpack_build-6d9b4da2d0-1/build.log
<!-- Replace `[ ]` with `[x]` if completed. --->

---
By making this pull request, I represent that I have read and agree to release my own changes that I
have submitted under the terms of the accompanying license (Apache-2.0). I guarantee that these
changes are mine and are not encumbered by any other license or restriction to the best of my
knowledge.

<!-- For co-authored commits, all co-authors will need to reply to this PR within a 48 Hrs.
If no replies have been left within a reasonable period, we may attempt to contact them by their
email tied to their commits, OR reject the PR at our discretion.

For Co-authoring docs, see:
https://docs.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors
--->
